### PR TITLE
Added negsoft-operator

### DIFF
--- a/charts/negsoft-operator/.helmignore
+++ b/charts/negsoft-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/negsoft-operator/Chart.yaml
+++ b/charts/negsoft-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: negsoft-operator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/charts/negsoft-operator/templates/NOTES.txt
+++ b/charts/negsoft-operator/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "negsoft-operator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "negsoft-operator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "negsoft-operator.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "negsoft-operator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/negsoft-operator/templates/_helpers.tpl
+++ b/charts/negsoft-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "negsoft-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "negsoft-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "negsoft-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "negsoft-operator.labels" -}}
+helm.sh/chart: {{ include "negsoft-operator.chart" . }}
+{{ include "negsoft-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "negsoft-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "negsoft-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "negsoft-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "negsoft-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/negsoft-operator/templates/clusterrole.yaml
+++ b/charts/negsoft-operator/templates/clusterrole.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+  name: {{ include "negsoft-operator.fullname" . }}-update-cronjobs
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - create
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+  name: {{ include "negsoft-operator.fullname" . }}-read-subscriptions
+rules:
+  - apiGroups:
+      - enthus.de
+    resources:
+      - negsoftsubscriptions
+    verbs:
+      - list
+      - watch
+{{- end -}}

--- a/charts/negsoft-operator/templates/clusterrolebinding.yaml
+++ b/charts/negsoft-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+  name: {{ include "negsoft-operator.fullname" . }}-update-cronjobs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "negsoft-operator.fullname" . }}-update-cronjobs
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "negsoft-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+  name: {{ include "negsoft-operator.fullname" . }}-read-subscriptions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "negsoft-operator.fullname" . }}-read-subscriptions
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "negsoft-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/negsoft-operator/templates/configmap.yaml
+++ b/charts/negsoft-operator/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "negsoft-operator.fullname" . }}
+data:
+  template_cronjob.yaml: |-
+    {{- include "negsoft-operator.cronjob_template" . | nindent 4 }}

--- a/charts/negsoft-operator/templates/cronjob_template.yaml
+++ b/charts/negsoft-operator/templates/cronjob_template.yaml
@@ -1,0 +1,60 @@
+{{- define "negsoft-operator.cronjob_template" -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "negsoft-operator.fullname" . }}
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+spec:
+  schedule: ""
+  timeZone: "Europe/Berlin"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "negsoft-operator.labels" . | nindent 8 }}
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: cronjob
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: "" # is overridden by operator
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /var/run/secret/cloud.google.com/service-account.json
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/nx
+                  readOnly: true
+                - name: gcp-service-account
+                  mountPath: /var/run/secret/cloud.google.com
+                  readOnly: true
+                - name: files
+                  mountPath: /mnt/files
+          volumes:
+            - name: config
+              configMap:
+                name: "" # is overridden by operator
+            - name: gcp-service-account
+              secret:
+                secretName: "" # is overridden by operator
+            - name: files
+              emptyDir: {} # is overridden by operator
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/negsoft-operator/templates/deployment.yaml
+++ b/charts/negsoft-operator/templates/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "negsoft-operator.fullname" . }}
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "negsoft-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "negsoft-operator.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "negsoft-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: MSSQL_HOSTNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: mssqlHostname
+            - name: MSSQL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: mssqlPort
+            - name: MSSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: mssqlUsername
+            - name: MSSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: mssqlPassword
+            - name: REDIS_ADDRESSES
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: redisAddresses
+            - name: REDIS_MASTER_SET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: redisMasterSet
+            - name: REDIS_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: redisDatabase
+            - name: CRONJOB_PREFIX
+              value: {{ .Values.cronjobPrefix }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "negsoft-operator.fullname" . }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/negsoft-operator/templates/secret.yaml
+++ b/charts/negsoft-operator/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "negsoft-operator.fullname" . }}-secret
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+type: Opaque
+data:
+  mssqlHostname: {{ .Values.secret.mssqlHostname | b64enc | quote }}
+  mssqlPort: {{ .Values.secret.mssqlPort | b64enc | quote }}
+  mssqlUsername: {{ .Values.secret.mssqlUsername | b64enc | quote }}
+  mssqlPassword: {{ .Values.secret.mssqlPassword | b64enc | quote }}
+  redisAddresses: {{ .Values.secret.redisAddresses | b64enc | quote }}
+  redisMasterSet: {{ .Values.secret.redisMasterSet | b64enc | quote }}
+  redisDatabase: {{ .Values.secret.redisDatabase | b64enc | quote }}

--- a/charts/negsoft-operator/templates/serviceaccount.yaml
+++ b/charts/negsoft-operator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "negsoft-operator.serviceAccountName" . }}
+  labels:
+    {{- include "negsoft-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/negsoft-operator/values.yaml
+++ b/charts/negsoft-operator/values.yaml
@@ -1,0 +1,112 @@
+# Default values for negsoft-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+rbac:
+  create: true
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+secret:
+  mssqlHostname: ""
+  mssqlPort: "1433"
+  mssqlUsername: ""
+  mssqlPassword: ""
+  redisAddresses: ""
+  redisMasterSet: ""
+  redisDatabase: "0"
+
+cronjobPrefix: ""


### PR DESCRIPTION
This pull request includes the initial setup of a Helm chart for the `negsoft-operator`. The changes include the creation of various Kubernetes resource templates and configuration files necessary for deploying and managing the application on a Kubernetes cluster.

### Helm Chart Setup:

* **Chart Metadata:**
  - Added `Chart.yaml` to define the chart metadata, including `apiVersion`, `name`, `description`, `type`, `version`, and `appVersion`.

* **Configuration and Values:**
  - Added `values.yaml` to define default configuration values for the chart, including image repository details, service account settings, RBAC settings, and resource limits.
  - Added `.helmignore` to specify patterns to ignore when building packages.

### Kubernetes Resource Templates:

* **Core Resources:**
  - Created `deployment.yaml` to define the deployment resource for the application, including container specifications, environment variables, and volume mounts.
  - Created `serviceaccount.yaml` to define the service account resource if specified in the values.
  - Created `secret.yaml` to define the secret resource for storing sensitive information like database credentials.
  - Created `configmap.yaml` to define the config map resource for configuration data.

* **RBAC Resources:**
  - Created `clusterrole.yaml` to define cluster roles for managing cronjobs and reading subscriptions.
  - Created `clusterrolebinding.yaml` to bind the service account to the cluster roles.

* **Utility Templates:**
  - Created `_helpers.tpl` to define helper templates for generating names and labels used across other resource templates.
  - Created `NOTES.txt` to provide post-installation instructions for accessing the application.
  - Created `cronjob_template.yaml` to define a template for creating cronjobs managed by the operator.