### PR TITLE
docs: rewrite README and sync Chart.yaml descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,39 @@
 # enthus Helm Charts
 
-## Getting started
+Helm charts maintained by enthus GmbH, published via GitHub Pages.
 
-Add the Helm charts to your helm command:
+## Usage
+
+Add the Helm repository:
+
+```shell
+helm repo add enthus https://enthus-appdev.github.io/helm-charts
+helm repo update
 ```
-helm repo add --username <username> --password <access_token> enthus-charts https://gitlab.com/api/v4/projects/42323755/packages/helm/stable
+
+Search available charts:
+
+```shell
+helm search repo enthus
 ```
 
-If you want to use the experimental/development versions use this one:
+Install a chart:
+
+```shell
+helm install my-release enthus/<chart-name>
 ```
-helm repo add --username <username> --password <access_token> enthus-experimental-charts https://gitlab.com/api/v4/projects/42323755/packages/helm/experimental
-```
 
+## Available charts
 
-## Charts
+| Chart | Description |
+|---|---|
+| [api-deployment](charts/api-deployment) | Deployment chart for the NegSoft API service |
+| [api-subscription](charts/api-subscription) | Deployment chart for the NegSoft subscription API workload |
+| [default](charts/default) | Default chart scaffold from `helm create` |
+| [negsoft-operator](charts/negsoft-operator) | Kubernetes operator for managing NegSoft user subscriptions |
+| [nexus](charts/nexus) | Internal admin UI for database operations, configuration, and cross-environment replication |
+| [pim-cronjob](charts/pim-cronjob) | Reusable Kubernetes CronJob chart for Product Information Management (PIM) workloads — importers, exporters, and generators |
 
-- [api-deployment](charts/api-deployment): Deployment Chart for API
-- [default](charts/default): Default Chart created by `helm create`
-- [rtf2html](charts/rtf2html): Deployment Chart for RTF to HTML converter
-- [sensa](charts/sensa): Deployment Chart for Sensa Bot
-- [service-voucher](charts/service-voucher): Deployment Chart for service voucher app
+## Contributing
+
+Charts are linted on every push and pull request. Release tarballs are published automatically via [chart-releaser-action](https://github.com/helm/chart-releaser-action) when version tags are pushed to `main`.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ helm install my-release enthus/<chart-name>
 
 ## Contributing
 
-Charts are linted on every push and pull request. Release tarballs are published automatically via [chart-releaser-action](https://github.com/helm/chart-releaser-action) when version tags are pushed to `main`.
+Charts are linted on every push and pull request. Release tarballs are published automatically via [chart-releaser-action](https://github.com/helm/chart-releaser-action) when version bumps are merged into `main`.

--- a/charts/api-deployment/Chart.yaml
+++ b/charts/api-deployment/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: api-deployment
-description: Deployment Helm chart for API
+description: Deployment chart for the NegSoft API service
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-subscription/Chart.yaml
+++ b/charts/api-subscription/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: api-subscription
-description: A Helm chart for Kubernetes
+description: Deployment chart for the NegSoft subscription API workload
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: default
-description: A Helm chart for Kubernetes
+description: Default chart scaffold from `helm create`
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/negsoft-operator/Chart.yaml
+++ b/charts/negsoft-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: negsoft-operator
-description: A Helm chart for Kubernetes
+description: Kubernetes operator for managing NegSoft user subscriptions
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nexus
-description: A Helm chart for Kubernetes
+description: Internal admin UI for database operations, configuration, and cross-environment replication
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/pim-cronjob/Chart.yaml
+++ b/charts/pim-cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pim-cronjob
-description: A Helm chart for Kubernetes
+description: Reusable Kubernetes CronJob chart for Product Information Management (PIM) workloads — importers, exporters, and generators
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary

- Rewrites `README.md` for the public chart repo:
  - Replaces the stale GitLab package-registry URL with the correct GitHub Pages URL (`https://enthus-appdev.github.io/helm-charts`)
  - Removes auth placeholders (the repo is public now)
  - Lists the actual 6 charts (the old README still listed `rtf2html`, `sensa`, and `service-voucher`, which were removed earlier in this session)
- Syncs each `Chart.yaml` `description:` field so `helm search repo enthus` shows the same text as the README
- Patch-bumps each chart's `version:` so `chart-releaser-action` picks up the metadata change and republishes

## Chart version bumps

| Chart | Old | New |
|---|---|---|
| api-deployment | 0.4.0 | 0.4.1 |
| api-subscription | 0.2.1 | 0.2.2 |
| default | 0.2.1 | 0.2.2 |
| negsoft-operator | 0.2.0 | 0.2.1 |
| nexus | 0.4.1 | 0.4.2 |
| pim-cronjob | 0.2.1 | 0.2.2 |

## Test plan

- [x] `Lint Helm Charts` workflow passes on this PR
- [ ] After merge, `Publish charts to repo` workflow runs and updates `gh-pages/index.yaml` with the new descriptions + new versions
- [ ] `helm repo update && helm search repo enthus` shows the new descriptions

## Side-issues spotted while in here (not in scope)

- `charts/api-subscription/values.yaml` has `image.repository: nginx` — leftover scaffold placeholder from `helm create`
- `charts/api-deployment/values.yaml` has `image.repository: registry.gitlab.com/mcldev/negsoft/api` — stale GitLab Container Registry reference