### PR TITLE
ci(lint): restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     name: "Lint Charts"
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Adds an explicit job-level `permissions:` block to `.github/workflows/lint.yml` that restricts `GITHUB_TOKEN` to `contents: read`.

The lint job only checks out the repo and runs `helm lint` — it doesn't need any write permissions. With no `permissions:` block, the token falls back to the repository default, which is broader than needed.

## Why

CodeQL flagged this as [alert #3](https://github.com/enthus-appdev/helm-charts/security/code-scanning/3): `actions/missing-workflow-permissions` (warning).

> Workflows should contain explicit permissions to restrict the scope of the default GITHUB_TOKEN.

The style mirrors `releaser.yml`, which already uses a job-level `permissions:` block (`pages: write, contents: write`).

## Test plan

- [x] `Lint Charts` workflow runs successfully on this PR with the reduced permissions
- [x] After merge, CodeQL alert #3 auto-resolves

Closes code-scanning alert #3.