### PR TITLE
feat(nexus)!: add config.provider discriminator (configMap | secretProviderClass)

### DIFF
--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nexus/templates/_helpers.tpl
+++ b/charts/nexus/templates/_helpers.tpl
@@ -60,3 +60,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate config.provider. Allowed values:
+  ""                    -> no /config volume mounted (caller wires its own)
+  "configMap"           -> render ConfigMap from config.configMap.values
+  "secretProviderClass" -> mount Secret Store CSI volume
+*/}}
+{{- define "nexus.validateConfigProvider" -}}
+{{- $p := .Values.config.provider -}}
+{{- if not (has $p (list "" "configMap" "secretProviderClass")) -}}
+{{- fail (printf "config.provider must be one of \"\", \"configMap\", \"secretProviderClass\"; got %q" $p) -}}
+{{- end -}}
+{{- if eq $p "secretProviderClass" -}}
+{{- if not .Values.config.secretProviderClass.name -}}
+{{- fail "config.provider=secretProviderClass requires config.secretProviderClass.name" -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/nexus/templates/configmap.yaml
+++ b/charts/nexus/templates/configmap.yaml
@@ -1,7 +1,12 @@
+{{- include "nexus.validateConfigProvider" . -}}
+{{- if eq .Values.config.provider "configMap" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nexus.fullname" . }}
+  labels:
+    {{- include "nexus.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{- toJson .Values.config | nindent 4 }}
+    {{- toJson .Values.config.configMap.values | nindent 4 }}
+{{- end }}

--- a/charts/nexus/templates/deployment.yaml
+++ b/charts/nexus/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "nexus.validateConfigProvider" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,13 +14,16 @@ spec:
       {{- include "nexus.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- if eq .Values.config.provider "configMap" }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "nexus.labels" . | nindent 8 }}
-	{{- with .Values.podLabels }}
+        {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
@@ -51,22 +55,29 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          {{- with .Values.config }}
+            {{- if .Values.config.provider }}
             - name: config
-              mountPath: /config
+              mountPath: {{ .Values.config.mountPath }}
               readOnly: true
-          {{- end }}
-          {{- with .Values.volumeMounts }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
       volumes:
-        {{- with .Values.config }}
+        {{- if eq .Values.config.provider "configMap" }}
         - name: config
           configMap:
-            name: {{ include "nexus.fullname" $ }}
+            name: {{ include "nexus.fullname" . }}
+        {{- else if eq .Values.config.provider "secretProviderClass" }}
+        - name: config
+          csi:
+            driver: {{ .Values.config.secretProviderClass.driver }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .Values.config.secretProviderClass.name }}
         {{- end }}
         {{- with .Values.volumes }}
-          {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/nexus/templates/secretproviderclass.yaml
+++ b/charts/nexus/templates/secretproviderclass.yaml
@@ -1,0 +1,13 @@
+{{- if and (eq .Values.config.provider "secretProviderClass") .Values.config.secretProviderClass.create }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.config.secretProviderClass.name }}
+  labels:
+    {{- include "nexus.labels" . | nindent 4 }}
+spec:
+  provider: {{ .Values.config.secretProviderClass.provider }}
+  parameters:
+    secrets: |
+      {{- toYaml .Values.config.secretProviderClass.secrets | nindent 6 }}
+{{- end }}

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -98,4 +98,35 @@ tolerations: []
 
 affinity: {}
 
-config: {}
+# Application configuration. The container reads a `config.json` file
+# mounted at `config.mountPath`. Pick exactly one provider:
+#
+#   provider: ""                     -> nothing is mounted; the caller
+#                                       wires the file through some other
+#                                       volume in `.Values.volumes`.
+#   provider: "configMap"            -> the chart renders a ConfigMap
+#                                       from `config.configMap.values`.
+#   provider: "secretProviderClass"  -> the chart mounts a CSI volume
+#                                       backed by a Secret Store CSI
+#                                       SecretProviderClass. Set
+#                                       `secretProviderClass.create: true`
+#                                       to also render the SPC resource.
+config:
+  provider: ""
+  mountPath: /config
+
+  configMap:
+    values: {}
+
+  secretProviderClass:
+    name: ""
+    create: false
+    provider: gke
+    driver: secrets-store-gke.csi.k8s.io
+    # Forwarded to `parameters.secrets` when `create: true`. To preserve
+    # the legacy ConfigMap shape, expose a single file named
+    # `config.json`:
+    #   secrets:
+    #     - resourceName: "projects/<project>/secrets/<secret>/versions/latest"
+    #       path: "config.json"
+    secrets: []


### PR DESCRIPTION
## Summary
Replace the implicit `{{ with .Values.config }}` truthiness checks in the nexus chart with an explicit `config.provider` discriminator. Three modes:

| `config.provider` | Behaviour |
|---|---|
| `""` | Nothing mounted at `/config`. Caller wires its own volume. |
| `"configMap"` | Chart renders a ConfigMap from `config.configMap.values` and mounts it. Pod gets a `checksum/config` annotation so edits actually roll. |
| `"secretProviderClass"` | Chart mounts a CSI volume backed by a Secret Store CSI `SecretProviderClass`. Set `secretProviderClass.create: true` and supply `secrets:` to also have the chart render the SPC resource. |

A `nexus.validateConfigProvider` helper rejects unknown providers and the common "secretProviderClass without name" mistake with a clear `fail` message at template time. `config.mountPath` is now configurable (still defaults to `/config`).

## Why
The chart previously inferred intent from the shape of `.Values.config` (truthy = render ConfigMap). That made the recent oauth2-proxy-style migration to GKE Secret Manager CSI in tool-nexus messy — `config: null` to disable internals plus extra `volumes`/`volumeMounts` blocks duplicating what the chart should own. With `provider` as a typed enum, callers state intent directly and invalid combinations are caught at template time instead of at apply time.

The new `checksum/config` annotation also closes the original tool-nexus regression where rotating the GCP secret left pods running stale config until a manual rollout.

## Breaking change
`config: {...}` no longer renders a ConfigMap. Existing callers must:
```yaml
# before
config:
  stage:
    server: ...

# after
config:
  provider: configMap
  configMap:
    values:
      stage:
        server: ...
```
Only consumer of this chart in the org is `tool-nexus`, which is migrating to `provider: secretProviderClass` in tool-nexus#401 — that PR will be updated to the new shape once this lands.

Chart version: 0.4.2 → 0.5.0.

## Test plan
Verified locally via `helm template` for each mode plus the two failure paths:

- [x] `provider: ""` (default) — no ConfigMap, no SPC, no `config` volume
- [x] `provider: configMap` — ConfigMap rendered, configmap volume mounted, `checksum/config` annotation present
- [x] `provider: secretProviderClass` (no `create`) — CSI volume only, no SPC rendered
- [x] `provider: secretProviderClass` with `create: true` — SPC rendered with the `secrets` list, CSI volume mounts it
- [x] `provider: bogus` — `fail` with allowed-values message
- [x] `provider: secretProviderClass` without `name` — `fail` with required-field message
- [x] `helm lint` clean
