### PR TITLE
fix(nexus): tighten config validation and skip empty pod annotations

### DIFF
--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nexus/templates/_helpers.tpl
+++ b/charts/nexus/templates/_helpers.tpl
@@ -72,9 +72,26 @@ Validate config.provider. Allowed values:
 {{- if not (has $p (list "" "configMap" "secretProviderClass")) -}}
 {{- fail (printf "config.provider must be one of \"\", \"configMap\", \"secretProviderClass\"; got %q" $p) -}}
 {{- end -}}
+{{- if $p -}}
+{{- if not .Values.config.mountPath -}}
+{{- fail "config.mountPath is required when config.provider is set" -}}
+{{- end -}}
+{{- end -}}
 {{- if eq $p "secretProviderClass" -}}
-{{- if not .Values.config.secretProviderClass.name -}}
+{{- $spc := .Values.config.secretProviderClass -}}
+{{- if not $spc.name -}}
 {{- fail "config.provider=secretProviderClass requires config.secretProviderClass.name" -}}
+{{- end -}}
+{{- if not $spc.driver -}}
+{{- fail "config.provider=secretProviderClass requires config.secretProviderClass.driver" -}}
+{{- end -}}
+{{- if $spc.create -}}
+{{- if not $spc.provider -}}
+{{- fail "config.secretProviderClass.create=true requires config.secretProviderClass.provider" -}}
+{{- end -}}
+{{- if not $spc.secrets -}}
+{{- fail "config.secretProviderClass.create=true requires a non-empty config.secretProviderClass.secrets list" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/nexus/templates/deployment.yaml
+++ b/charts/nexus/templates/deployment.yaml
@@ -14,13 +14,20 @@ spec:
       {{- include "nexus.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- $configMapChecksum := eq .Values.config.provider "configMap" }}
+      {{- $spcChecksum := and (eq .Values.config.provider "secretProviderClass") .Values.config.secretProviderClass.create }}
+      {{- if or $configMapChecksum $spcChecksum .Values.podAnnotations }}
       annotations:
-        {{- if eq .Values.config.provider "configMap" }}
+        {{- if $configMapChecksum }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if $spcChecksum }}
+        checksum/config: {{ include (print $.Template.BasePath "/secretproviderclass.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       labels:
         {{- include "nexus.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
## Summary
Follow-up on review feedback from #14:

- **Skip empty `annotations:` block.** The deployment template emitted an empty `annotations:` key whenever the provider wasn't `configMap` and `podAnnotations` was empty. The block is now gated on actually having something to write.
- **Checksum the SecretProviderClass too** when `create: true`, so edits to the chart-managed SPC roll the pod the same way ConfigMap edits do.
- **Tighten `nexus.validateConfigProvider`:**
  - `config.mountPath` is required whenever `config.provider` is set.
  - `secretProviderClass` requires `driver`.
  - `secretProviderClass.create: true` additionally requires `provider` and a non-empty `secrets` list (otherwise the SPC would render incomplete and apply would fail with a less clear error).

Chart version: 0.5.0 → 0.5.1.

## Test plan
- [x] `provider: ""` (default) — no `annotations:` block in the deployment
- [x] `provider: secretProviderClass` with `create: false` — no `annotations:` block
- [x] `provider: configMap` — `checksum/config` annotation present
- [x] `provider: secretProviderClass` with `create: true` — `checksum/config` annotation present (hashing the SPC)
- [x] `mountPath: ""` with provider set — `fail` "config.mountPath is required when config.provider is set"
- [x] SPC with empty `driver` — `fail` with required-field message
- [x] SPC with `create: true` but missing `provider` — `fail`
- [x] SPC with `create: true` but empty `secrets` — `fail`
- [x] `helm lint` clean
