### PR TITLE
feat: NX-15696 pass nodeSelector + tolerations through api-subscription CR

### DIFF
--- a/charts/api-subscription/Chart.yaml
+++ b/charts/api-subscription/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-subscription/templates/subscription.yaml
+++ b/charts/api-subscription/templates/subscription.yaml
@@ -19,6 +19,14 @@ spec:
   affinity:
     {{ toYaml . | nindent 4}}
   {{- end }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{ toYaml . | nindent 4}}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{ toYaml . | nindent 4}}
+  {{- end }}
   {{- with .Values.env }}
   env:
     {{ toYaml . | nindent 4}}

--- a/charts/api-subscription/values.yaml
+++ b/charts/api-subscription/values.yaml
@@ -25,6 +25,10 @@ resources: {}
 
 affinity: {}
 
+nodeSelector: {}
+
+tolerations: []
+
 args: []
 
 config: {}


### PR DESCRIPTION
## What & Why

Part of [NX-15696](https://enthus.atlassian.net/browse/NX-15696). Companion to enthus-appdev/negsoft-subscription-operator#90, which adds `nodeSelector`/`tolerations` to the `NegSoftSubscription` CRD + applies them to the generated CronJobs. This exposes both as `api-subscription` chart values and templates them into the CR, so subscription export jobs can be pinned to the **tainted** `mts-export` highmem pool (the affinity-only path couldn't express the required toleration).

## Key Changes

- `templates/subscription.yaml`: template `spec.nodeSelector` and `spec.tolerations` (mirroring the existing `affinity` passthrough).
- `values.yaml`: `nodeSelector: {}` + `tolerations: []` defaults.
- Chart `0.2.2` → `0.3.0`.

## Testing

`helm lint` clean. `helm template` with the live `negsoft-api/deployments/productive/values-subscription.yaml` renders the CR with `nodeSelector: enthus.de/dedicated=mts-export` + the matching `NoSchedule` toleration.

## Deployment Notes

**Strict order** — the CRD schema is structural and prunes unknown fields. Do **not** ship this chart version until the operator PR has landed and:
1. updated CRD applied (`kubectl apply` operator `apis/enthus.de_negsoftsubscriptions.yaml`),
2. new operator image rolled out,
3. **then** this chart + values. Reverse order → fields silently pruned off the CR.

[NX-15696]: https://enthus.atlassian.net/browse/NX-15696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ