### PR TITLE
feat: NX-15715 add generic healthcheck chart

### DIFF
--- a/charts/healthcheck/.helmignore
+++ b/charts/healthcheck/.helmignore
@@ -1,0 +1,6 @@
+# Patterns to ignore when building packages.
+*.tmpl
+.git
+.gitignore
+.vscode
+*.md

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: healthcheck
+description: In-cluster post-deploy health-check probe (browser render + API + live-query round-trip) that reports red/green to Discord.
+type: application
+version: 0.1.0
+appVersion: "1.0"
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/healthcheck/templates/_helpers.tpl
+++ b/charts/healthcheck/templates/_helpers.tpl
@@ -1,0 +1,128 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "healthcheck.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "healthcheck.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "healthcheck.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "healthcheck.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "healthcheck.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "healthcheck.labels" -}}
+helm.sh/chart: {{ include "healthcheck.chart" . }}
+{{ include "healthcheck.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "healthcheck.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "healthcheck.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pod template spec shared by the CronJob and the on-demand Job, so an ad-hoc
+`kubectl create job --from=cronjob/...` and the scheduled run are identical.
+The probe image is self-contained (browser + probe baked in); the pod only
+supplies config via env and a writable /tmp for the read-only root filesystem.
+*/}}
+{{- define "healthcheck.podSpec" -}}
+serviceAccountName: {{ include "healthcheck.serviceAccountName" . }}
+automountServiceAccountToken: false
+restartPolicy: Never
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+containers:
+  - name: probe
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+    env:
+      # readOnlyRootFilesystem: keep all writes (browser profile, cache) in /tmp.
+      - name: HOME
+        value: /tmp
+      - name: ENV_LABEL
+        value: {{ .Values.envLabel | quote }}
+      - name: REPORT_ON
+        value: {{ .Values.reportOn | quote }}
+      - name: SOURCE_IP
+        value: {{ .Values.sourceIp | quote }}
+      - name: COOKIE_NAME
+        value: {{ .Values.cookieName | quote }}
+      - name: EXPECTED_SHA
+        value: {{ .Values.expectedSha | quote }}
+      - name: API_BASE
+        value: {{ .Values.targets.apiBase | quote }}
+      - name: GUI_BASE
+        value: {{ .Values.targets.guiBase | quote }}
+      - name: LEGACY_BASE
+        value: {{ .Values.targets.legacyBase | quote }}
+      - name: REPLICA_BASES
+        value: {{ join "," (.Values.targets.replicas | default (list)) | quote }}
+      - name: SHOT
+        value: /tmp/render.png
+      {{- if .Values.discord.webhookSecretName }}
+      - name: DISCORD_WEBHOOK_URL
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.discord.webhookSecretName | quote }}
+            key: {{ .Values.discord.webhookSecretKey | quote }}
+            optional: false
+      {{- end }}
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+volumes:
+  - name: tmp
+    emptyDir: {}
+{{- end -}}

--- a/charts/healthcheck/templates/_helpers.tpl
+++ b/charts/healthcheck/templates/_helpers.tpl
@@ -99,22 +99,24 @@ containers:
         value: {{ .Values.cookieName | quote }}
       - name: EXPECTED_SHA
         value: {{ .Values.expectedSha | quote }}
+      {{- $targets := .Values.targets | default dict }}
       - name: API_BASE
-        value: {{ .Values.targets.apiBase | quote }}
+        value: {{ $targets.apiBase | default "" | quote }}
       - name: GUI_BASE
-        value: {{ .Values.targets.guiBase | quote }}
+        value: {{ $targets.guiBase | default "" | quote }}
       - name: LEGACY_BASE
-        value: {{ .Values.targets.legacyBase | quote }}
+        value: {{ $targets.legacyBase | default "" | quote }}
       - name: REPLICA_BASES
-        value: {{ join "," (.Values.targets.replicas | default (list)) | quote }}
+        value: {{ join "," ($targets.replicas | default (list)) | quote }}
       - name: SHOT
         value: /tmp/render.png
-      {{- if .Values.discord.webhookSecretName }}
+      {{- $discord := .Values.discord | default dict }}
+      {{- if $discord.webhookSecretName }}
       - name: DISCORD_WEBHOOK_URL
         valueFrom:
           secretKeyRef:
-            name: {{ .Values.discord.webhookSecretName | quote }}
-            key: {{ .Values.discord.webhookSecretKey | quote }}
+            name: {{ $discord.webhookSecretName | quote }}
+            key: {{ $discord.webhookSecretKey | default "webhook-url" | quote }}
             optional: false
       {{- end }}
     resources:

--- a/charts/healthcheck/templates/cronjob.yaml
+++ b/charts/healthcheck/templates/cronjob.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.schedule }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "healthcheck.fullname" . }}
+  labels:
+    {{- include "healthcheck.labels" . | nindent 4 }}
+    mcl.sh/name: healthcheck
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  {{- with .Values.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 120
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            {{- include "healthcheck.labels" . | nindent 12 }}
+            mcl.sh/name: healthcheck
+        spec:
+          {{- include "healthcheck.podSpec" . | nindent 10 }}
+{{- end }}

--- a/charts/healthcheck/templates/job.yaml
+++ b/charts/healthcheck/templates/job.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     {{- include "healthcheck.labels" . | nindent 4 }}
     mcl.sh/name: healthcheck
-  annotations:
-    # Render the Job only on demand (e.g. CI post-deploy with a unique suffix).
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: 300

--- a/charts/healthcheck/templates/job.yaml
+++ b/charts/healthcheck/templates/job.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.job.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "healthcheck.fullname" . }}-{{ .Values.job.suffix | default "run" }}
+  labels:
+    {{- include "healthcheck.labels" . | nindent 4 }}
+    mcl.sh/name: healthcheck
+  annotations:
+    # Render the Job only on demand (e.g. CI post-deploy with a unique suffix).
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "healthcheck.labels" . | nindent 8 }}
+        mcl.sh/name: healthcheck
+    spec:
+      {{- include "healthcheck.podSpec" . | nindent 6 }}
+{{- end }}

--- a/charts/healthcheck/templates/networkpolicy.yaml
+++ b/charts/healthcheck/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "healthcheck.fullname" . }}
+  labels:
+    {{- include "healthcheck.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "healthcheck.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/healthcheck/templates/serviceaccount.yaml
+++ b/charts/healthcheck/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "healthcheck.serviceAccountName" . }}
+  labels:
+    {{- include "healthcheck.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# No RBAC RoleBinding is created: the probe needs zero Kubernetes API access.
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -1,0 +1,79 @@
+# Default values for the post-deploy health check.
+#
+# This chart only runs the probe image; the probe code and the per-environment
+# values (target service DNS, identity, cookie) live in the private
+# negsoft-healthcheck repo. Defaults below are placeholders — every deployment
+# supplies a values file.
+
+# Probe image (private — pulled in-cluster). Pin a sha-<commit> tag per
+# environment for reproducibility; `latest` is only the placeholder default.
+image:
+  repository: europe-west3-docker.pkg.dev/mcl-development/ghcr-enthus-appdev-remote/enthus-appdev/negsoft-healthcheck
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+# Context label shown in the report.
+envLabel: ""
+
+# Reporting policy: "always" posts every run, "failure" posts only on red.
+reportOn: failure
+
+# Source IP the probe presents for its read-only identity. Set per environment.
+sourceIp: ""
+
+# Session cookie name the probe reads back. Environment-specific; set per env.
+cookieName: ""
+
+# If set, the probe asserts the deployed build matches this commit SHA.
+# Empty = reachability only.
+expectedSha: ""
+
+# In-cluster targets (ClusterIP service URLs). Set per environment.
+targets:
+  apiBase: ""
+  guiBase: ""
+  legacyBase: ""
+  # Replica services to liveness-check. Empty -> skipped.
+  replicas: []
+
+discord:
+  # Kubernetes Secret holding the Discord webhook URL (created out-of-band,
+  # never templated through values). Empty -> reporting disabled.
+  webhookSecretName: ""
+  webhookSecretKey: webhook-url
+
+# Ambient schedule. "" disables the CronJob (e.g. environments that scale to
+# zero outside work hours and run only on deploy).
+schedule: ""
+timeZone: "Europe/Berlin"
+
+# On-demand one-shot Job, rendered only when enabled (e.g. a CI post-deploy run
+# with a unique suffix).
+job:
+  enabled: false
+  suffix: run
+
+# Optional NetworkPolicy. Off by default to match clusters that don't enforce
+# NetworkPolicy. Enable on clusters that do (e.g. Dataplane V2) and supply the
+# ingress/egress rules the probe needs (egress to the target services, DNS, and
+# the reporting webhook).
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi


### PR DESCRIPTION
## What & Why

Adds a **public, generic, image-based** `healthcheck` chart. Part of NX-15715: the post-deploy health check is being decoupled from `negsoft-api` into three clean repos — this is the **public chart** half. It runs the private probe image and reports red/green to Discord.

The chart is deliberately **free of probe code, auth mechanism, IPs, and environment-specific values** — every deployment supplies a values file. The probe (`probe.mjs`) and the private per-env values live in the private [`negsoft-healthcheck`](https://github.com/enthus-appdev/negsoft-healthcheck) repo; the image is private.

## Key changes vs the old negsoft-api chart

- **Image-based** — the probe is baked into `ghcr.io/enthus-appdev/negsoft-healthcheck`. Drops the old init-container `npm install playwright-core`, the probe ConfigMap, and the `pw`/`probe` volumes.
- **Scrubbed** — placeholder values + neutral comments. The grep gate (`autologin|forwarded|s_ipaddress|_mclses_id|_devses_id|x-forwarded|monitor|<real IPs>|nx-stage|nx-prod`) returns **zero hits**.
- **NetworkPolicy** — now an optional templated block (default off; enable on clusters that enforce it, e.g. Dataplane V2). The old chart's leaky "this cluster has no NetworkPolicy" comment is gone.
- Pod hardening preserved verbatim: zero-RBAC SA, `automountServiceAccountToken: false`, non-root, read-only root FS, dropped caps, seccomp.

## Verification

- `helm lint charts/healthcheck` → 0 failed (only the cosmetic "icon is recommended" INFO).
- `helm template` renders Job, CronJob, ServiceAccount, NetworkPolicy correctly; image ref resolves; no init-container / ConfigMap / playwright leftovers.
- Recipe grep gate: **zero hits** across the chart.

## Follow-ups (this stack)

- `actions/healthcheck` rewire to consume this chart + the private values — verified on stage before merge.
- `negsoft-api` removes its `charts/healthcheck/*` after the action is cut over and GREEN.

The negsoft-api chart stays the live path until then, so nothing in production changes on merge here (the chart is published to the index but not yet referenced).
