### PR TITLE
feat: add extraObjects support to default chart (0.3.0)

### DIFF
--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/default/templates/extra-objects.yaml
+++ b/charts/default/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -81,3 +81,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Arbitrary objects rendered verbatim alongside the release, e.g. Traefik
+# IngressRoute/Middleware CRDs the built-in templates do not cover. Each entry
+# may be a structured map or a raw YAML string block, and is run through `tpl`,
+# so values may reference .Release/.Values. Because entries are templated, treat
+# this as deploy-time trusted input only — do not source it from untrusted callers.
+extraObjects: []


### PR DESCRIPTION
## What

Adds an `extraObjects` list to the shared `default` chart so a release can ship arbitrary Kubernetes objects (e.g. Traefik `IngressRoute`/`Middleware` CRDs) verbatim alongside its workload. Bumps `charts/default` **0.2.2 → 0.3.0**.

- `templates/extra-objects.yaml`: `{{- range .Values.extraObjects }}---\n{{ tpl (toYaml .) $ }}{{- end }}` — each entry is `tpl`-evaluated, so values may reference `.Release`/`.Values`.
- `values.yaml`: `extraObjects: []` default.

## Why

The built-in templates only render a classic `Ingress`. The ew4 (europe-west4) cluster migration standardises on Traefik `IngressRoute` CRDs (`traefik.io/v1alpha1`) for routing. Without this, frontends (gui/screens/sidebar) can't carry their routes inside their own Helm release and would need out-of-band `kubectl apply` (the orphaned hand-applied route objects this migration is replacing).

## Compatibility

Fully backward compatible — `extraObjects` defaults to `[]` and renders nothing for existing consumers.

## Verification

```
helm lint .                          # passes
helm template t .                    # IngressRoute count: 0 (empty default)
helm template t . --set-json extraObjects='[{IngressRoute ...}]'   # renders correctly
```

## Consumers

First consumer: `negsoft-gui` ew4 `values-ew4.yaml` (separate PR). **This must be merged and the chart published to the repo index before the gui ew4 deploy resolves `extraObjects`.**

> Part of the GKE ew4 (europe-west4) frontend migration. No Jira ticket linked yet — happy to add one.