### PR TITLE
feat: add optional csiSecrets to api-deployment

### DIFF
--- a/charts/api-deployment/Chart.yaml
+++ b/charts/api-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-deployment/templates/deployment.yaml
+++ b/charts/api-deployment/templates/deployment.yaml
@@ -86,6 +86,11 @@ spec:
               mountPath: {{ .mountPath | quote }}
               readOnly: {{ .readOnly | default true }} # Enforce read-only by default to enhance security
           {{- end }}
+          {{- range .Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: true
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -122,4 +127,12 @@ spec:
           configMap:
             name: {{ .configMapName | quote }}
             optional: {{ .optional | default false }} # Ensure configmap is present by default
+        {{- end }}
+        {{- range .Values.csiSecrets }}
+        - name: {{ .name | quote }}
+          csi:
+            driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .secretProviderClass | quote }}
         {{- end }}

--- a/charts/api-deployment/templates/secretproviderclass.yaml
+++ b/charts/api-deployment/templates/secretproviderclass.yaml
@@ -1,0 +1,19 @@
+{{- range $.Values.csiSecrets }}
+{{- if .secretProviderClass }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .secretProviderClass | quote }}
+  labels:
+    {{- include "api-deployment.labels" $ | nindent 4 }}
+spec:
+  provider: {{ .provider | default "gke" }}
+  parameters:
+    secrets: |
+      {{- range .secrets }}
+      - resourceName: {{ .resourceName | quote }}
+        path: {{ .path | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -135,6 +135,18 @@ configMaps: []
   #   readOnly: true
   #   optional: false
 
+# CSI-mounted secrets (Secrets Store CSI driver + Workload Identity): the pod's identity
+# fetches the secret from the cloud secret manager and mounts it as a file (never in etcd).
+# A container reads it from the mount path, e.g. via an *_FILE env var. Default off (empty).
+csiSecrets: []
+  # - name: my-secret
+  #   mountPath: /var/run/secret/my-secret
+  #   secretProviderClass: my-secret-provider
+  #   provider: gke
+  #   secrets:
+  #     - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
+  #       path: "my-secret-file"
+
 volume:
   data:
     volumeClaim: ""


### PR DESCRIPTION
## What
Adds a flag-gated `csiSecrets` list to the `api-deployment` chart that mounts secrets from a cloud secret manager via the **Secrets Store CSI driver** (file-mount, fetched by the pod's identity), plus a matching `SecretProviderClass` template. Mirrors the pattern already used by the `cron` chart.

## Why
Lets a deployment receive a secret as a mounted file — e.g. a database password read via an `*_FILE` env var — without putting it in a ConfigMap or a synced k8s Secret.

## Notes
- **Default off** (`csiSecrets: []`); existing deployments are unchanged.
- Verified with `helm template`: off → no CSI objects; on → `SecretProviderClass` + CSI volume + mount render correctly.
