### PR TITLE
feat: migrate api-portal/manager/notification/job charts from negsoft-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ helm install my-release enthus/<chart-name>
 | Chart | Description |
 |---|---|
 | [api-deployment](charts/api-deployment) | Deployment chart for the NegSoft API service |
+| [api-job-cronjob](charts/api-job-cronjob) | Reusable CronJob chart for the NegSoft job service (scheduled tasks) |
+| [api-manager-deployment](charts/api-manager-deployment) | Deployment chart for the NegSoft manager (cross-service orchestration) service |
+| [api-notification-deployment](charts/api-notification-deployment) | Deployment chart for the NegSoft notification WebSocket service |
+| [api-portal-deployment](charts/api-portal-deployment) | Deployment chart for the NegSoft Portal (customer-facing) API service |
 | [api-subscription](charts/api-subscription) | Deployment chart for the NegSoft subscription API workload |
 | [default](charts/default) | Default chart scaffold from `helm create` |
 | [negsoft-operator](charts/negsoft-operator) | Kubernetes operator for managing NegSoft user subscriptions |

--- a/charts/api-job-cronjob/.helmignore
+++ b/charts/api-job-cronjob/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/api-job-cronjob/Chart.yaml
+++ b/charts/api-job-cronjob/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: api-job-cronjob
+description: Reusable CronJob chart for the NegSoft job service (scheduled tasks)
+type: application
+version: 0.5.0
+appVersion: "1.0.0"
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/api-job-cronjob/templates/_helpers.tpl
+++ b/charts/api-job-cronjob/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "api-job-cronjob.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "api-job-cronjob.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "api-job-cronjob.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "api-job-cronjob.labels" -}}
+helm.sh/chart: {{ include "api-job-cronjob.chart" . }}
+app.kubernetes.io/name: {{ include "api-job-cronjob.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "api-job-cronjob.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "api-job-cronjob.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/api-job-cronjob/templates/configmap.yaml
+++ b/charts/api-job-cronjob/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "api-job-cronjob.fullname" . }}
+data:
+  config.yaml: |-
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/api-job-cronjob/templates/cronjob.yaml
+++ b/charts/api-job-cronjob/templates/cronjob.yaml
@@ -1,0 +1,138 @@
+{{- range $i, $job := .Values.cronjobs }}
+{{ if gt $i 0 }}---{{ end }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  {{- $name := default $job.name $job.nameOverride }}
+  name: {{ printf "%s-%s" (include "api-job-cronjob.fullname" $) $name | lower | trunc 52 | trimSuffix "-"}}
+  labels:
+    app.kubernetes.io/name: {{ include "api-job-cronjob.name" $ }}
+    helm.sh/chart: {{ include "api-job-cronjob.chart" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    mcl.sh/name: cronjob
+    mcl.sh/job: {{ $job.name }}
+spec:
+  {{- $timeZone := default $.Values.timeZone $job.timeZone }}
+  {{- with $timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  schedule: {{ $job.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  {{- $startingDeadlineSeconds := default $.Values.startingDeadlineSeconds $job.startingDeadlineSeconds }}
+  {{- with $startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ . }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+        {{- with $.Values.podAnnotations }}
+          annotations:
+            {{ toYaml . | nindent 12 }}
+        {{- end }}
+          labels:
+            app.kubernetes.io/name: {{ include "api-job-cronjob.name" $ }}
+            app.kubernetes.io/instance: {{ $.Release.Name }}
+            mcl.sh/name: cronjob
+            mcl.sh/job: {{ $job.name }}
+        spec:
+          serviceAccountName: {{ include "api-job-cronjob.serviceAccountName" $ }}
+          containers:
+            - name: {{ printf "%s-%s" $.Chart.Name $job.name | lower | trunc 63 | trimSuffix "-" }}
+              image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              args:
+                {{- range $.Values.extraArgs }}
+                - {{ . | quote }}
+                {{- end }}
+                - "--name"
+                - {{ $job.name | quote }}
+              {{- with $.Values.env }}
+              env:
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- with $.Values.envFrom }}
+              envFrom:
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
+              {{- $resources := default $.Values.resources $job.resources }}
+              resources:
+                {{ toYaml $resources | nindent 16 }}
+              volumeMounts:
+              {{- with $.Values.config }}
+                - name: config
+                  mountPath: /etc/nx
+                  readOnly: true
+              {{- end }}
+                - name: files
+                  mountPath: /mnt/files
+              {{- range $.Values.secrets }}
+                - name: {{ .name | quote }}
+                  mountPath: {{ .mountPath | quote }}
+                  readOnly: {{ .readOnly | default true }}
+              {{- end }}
+              {{- range $.Values.configMaps }}
+                - name: {{ .name | quote }}
+                  mountPath: {{ .mountPath | quote }}
+                  readOnly: {{ .readOnly | default true }}
+              {{- end }}
+              {{- range $.Values.csiSecrets }}
+                - name: {{ .name | quote }}
+                  mountPath: {{ .mountPath | quote }}
+                  readOnly: true
+              {{- end }}
+        {{- $nodeSelector := default $.Values.nodeSelector $job.nodeSelector -}}
+        {{- with $nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- $affinity := default $.Values.affinity $job.affinity -}}
+        {{- with $affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- $tolerations := default $.Values.tolerations $job.tolerations -}}
+        {{- with $tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with $.Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+          volumes:
+          {{- with $.Values.config }}
+            - name: config
+              configMap:
+                name: {{ include "api-job-cronjob.fullname" $ }}
+          {{- end }}
+            - name: files
+            {{- if $.Values.volume.data.volumeClaim }}
+              persistentVolumeClaim:
+                claimName: {{ $.Values.volume.data.volumeClaim }}
+            {{- else }}
+              emptyDir: {}
+            {{- end }}
+          {{- range $.Values.secrets }}
+            - name: {{ .name | quote }}
+              secret:
+                secretName: {{ .secretName | quote }}
+                optional: {{ .optional | default false }}
+          {{- end }}
+          {{- range $.Values.configMaps }}
+            - name: {{ .name | quote }}
+              configMap:
+                name: {{ .configMapName | quote }}
+                optional: {{ .optional | default false }}
+          {{- end }}
+          {{- range $.Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              csi:
+                driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+                readOnly: true
+                volumeAttributes:
+                  secretProviderClass: {{ .secretProviderClass | quote }}
+          {{- end }}
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/api-job-cronjob/templates/secretproviderclass.yaml
+++ b/charts/api-job-cronjob/templates/secretproviderclass.yaml
@@ -1,0 +1,19 @@
+{{- range $.Values.csiSecrets }}
+{{- if .secretProviderClass }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .secretProviderClass | quote }}
+  labels:
+    {{- include "api-job-cronjob.labels" $ | nindent 4 }}
+spec:
+  provider: {{ .provider | default "gke" }}
+  parameters:
+    secrets: |
+      {{- range .secrets }}
+      - resourceName: {{ .resourceName | quote }}
+        path: {{ .path | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/api-job-cronjob/templates/serviceaccount.yaml
+++ b/charts/api-job-cronjob/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-job-cronjob.serviceAccountName" . }}
+  labels:
+    {{- include "api-job-cronjob.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/api-job-cronjob/values.yaml
+++ b/charts/api-job-cronjob/values.yaml
@@ -1,0 +1,102 @@
+# Default values for cron.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: ghcr.io/enthus-appdev/negsoft-api/job
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+#    - name: pull-secret
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+extraArgs: []
+podAnnotations: {}
+
+cronjobs: []
+#  - name: "test"
+#    schedule: "0 0 0 0 0"
+#    timeZone: ""
+#    resources: {}
+#      # We usually recommend not to specify default resources and to leave this as a conscious
+#      # choice for the user. This also increases chances charts run on environments with little
+#      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+#      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#      # limits:
+#      #  cpu: 100m
+#      #  memory: 128Mi
+#      # requests:
+#      #  cpu: 100m
+#      #  memory: 128Mi
+#    nodeSelector: {}
+#    tolerations: []
+#    affinity: {}
+#    startingDeadlineSeconds: 0
+
+# startingDeadlineSeconds: 0
+timeZone: ""
+
+volume:
+  data:
+    volumeClaim: ""
+
+env: []
+  # - name: MY_STATIC_VAR
+  #   value: "my_value"
+  # - name: MY_CONFIG_VAR
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: my-configmap
+  #       key: config-key
+  #       optional: false
+  # - name: MY_SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: secret-key
+  #       optional: false
+
+envFrom: []
+  # - configMapRef:
+  #     name: my-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: my-secret
+  #     optional: false
+
+secrets: []
+  # - name: cert-secret
+  #   secretName: my-certificate-secret
+  #   mountPath: /etc/certs
+  #   readOnly: true
+  #   optional: false
+
+configMaps: []
+  # - name: app-config
+  #   configMapName: my-app-config
+  #   mountPath: /etc/config
+  #   readOnly: true
+  #   optional: false
+
+csiSecrets: []
+  # - name: my-secret
+  #   mountPath: /var/run/secret/my-secret
+  #   secretProviderClass: my-secret-provider
+  #   provider: gke                # default: gke (GKE managed addon)
+  #   driver: secrets-store-gke.csi.k8s.io  # default: secrets-store-gke.csi.k8s.io
+  #   secrets:
+  #     - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
+  #       path: "my-secret-file"
+
+config: {}

--- a/charts/api-manager-deployment/.helmignore
+++ b/charts/api-manager-deployment/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/api-manager-deployment/Chart.yaml
+++ b/charts/api-manager-deployment/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: api-manager-deployment
+description: Deployment chart for the NegSoft manager (cross-service orchestration) service
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.5.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/api-manager-deployment/templates/_helpers.tpl
+++ b/charts/api-manager-deployment/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "api-manager-deployment.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "api-manager-deployment.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "api-manager-deployment.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "api-manager-deployment.labels" -}}
+helm.sh/chart: {{ include "api-manager-deployment.chart" . }}
+{{ include "api-manager-deployment.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "api-manager-deployment.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "api-manager-deployment.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "api-manager-deployment.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "api-manager-deployment.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/api-manager-deployment/templates/clusterrole.yaml
+++ b/charts/api-manager-deployment/templates/clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "api-manager-deployment.selectorLabels" . | nindent 4 }}
+  name: {{ include "api-manager-deployment.fullname" . }}
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - list
+      - delete
+{{- end -}}

--- a/charts/api-manager-deployment/templates/clusterrolebinding.yaml
+++ b/charts/api-manager-deployment/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "api-manager-deployment.selectorLabels" . | nindent 4 }}
+  name: {{ template "api-manager-deployment.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "api-manager-deployment.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "api-manager-deployment.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/api-manager-deployment/templates/configmap.yaml
+++ b/charts/api-manager-deployment/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "api-manager-deployment.fullname" . }}
+data:
+  config.yaml: |-
+    {{- toYaml .Values.config | nindent 4 }}
+  template_job.yaml: |-
+    {{- include "api-manager-deployment.job" . | nindent 4 }}

--- a/charts/api-manager-deployment/templates/deployment.yaml
+++ b/charts/api-manager-deployment/templates/deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "api-manager-deployment.fullname" . }}
+  labels:
+    {{- include "api-manager-deployment.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "api-manager-deployment.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "api-manager-deployment.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "api-manager-deployment.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range .Values.globalArgs }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- range .Values.args }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- with .Values.config }}
+            - name: config
+              mountPath: /etc/nx
+              readOnly: true
+          {{- end }}
+          {{- range .Values.secrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.configMaps }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- with .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "api-manager-deployment.fullname" $ }}
+        {{- end }}
+        {{- range .Values.secrets }}
+        - name: {{ .name | quote }}
+          secret:
+            secretName: {{ .secretName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.configMaps }}
+        - name: {{ .name | quote }}
+          configMap:
+            name: {{ .configMapName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.csiSecrets }}
+        - name: {{ .name | quote }}
+          csi:
+            driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .secretProviderClass | quote }}
+        {{- end }}

--- a/charts/api-manager-deployment/templates/job.yaml
+++ b/charts/api-manager-deployment/templates/job.yaml
@@ -1,0 +1,107 @@
+{{- define "api-manager-deployment.job" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "api-manager-deployment.fullname" . }}-job
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "api-manager-deployment.labels" . | nindent 4 }}
+spec:
+  completions: 1
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "api-manager-deployment.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.job.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-job
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.job.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range .Values.globalArgs }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          resources:
+            {{ toYaml .Values.job.resources | nindent 12 }}
+          volumeMounts:
+            {{- with .Values.config }}
+            - name: config
+              mountPath: /etc/nx
+              readOnly: true
+            {{- end }}
+            - name: files
+              mountPath: /mnt/files
+          {{- range .Values.secrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.configMaps }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+      {{- with .Values.job.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.job.tolerations }}
+      tolerations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- with .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "api-manager-deployment.fullname" $ }}
+        {{- end }}
+        - name: files
+          {{- if .Values.volume.data.volumeClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.volume.data.volumeClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- range .Values.secrets }}
+        - name: {{ .name | quote }}
+          secret:
+            secretName: {{ .secretName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.configMaps }}
+        - name: {{ .name | quote }}
+          configMap:
+            name: {{ .configMapName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/charts/api-manager-deployment/templates/secretproviderclass.yaml
+++ b/charts/api-manager-deployment/templates/secretproviderclass.yaml
@@ -1,0 +1,19 @@
+{{- range $.Values.csiSecrets }}
+{{- if .secretProviderClass }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .secretProviderClass | quote }}
+  labels:
+    {{- include "api-manager-deployment.labels" $ | nindent 4 }}
+spec:
+  provider: {{ .provider | default "gke" }}
+  parameters:
+    secrets: |
+      {{- range .secrets }}
+      - resourceName: {{ .resourceName | quote }}
+        path: {{ .path | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/api-manager-deployment/templates/service.yaml
+++ b/charts/api-manager-deployment/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api-manager-deployment.fullname" . }}
+  labels:
+    {{- include "api-manager-deployment.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "api-manager-deployment.selectorLabels" . | nindent 4 }}

--- a/charts/api-manager-deployment/templates/serviceaccount.yaml
+++ b/charts/api-manager-deployment/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-manager-deployment.serviceAccountName" . }}
+  labels:
+    {{- include "api-manager-deployment.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/api-manager-deployment/values.yaml
+++ b/charts/api-manager-deployment/values.yaml
@@ -1,0 +1,153 @@
+# Default values for manager.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: "ghcr.io/enthus-appdev/negsoft-api/manager"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+rbac:
+  create: true
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# job template
+job:
+  # The K8s service account name for spawned jobs.
+  # Should match the cron chart's SA since these jobs run the same binary.
+  serviceAccountName: ""
+
+  image:
+    repository: "ghcr.io/enthus-appdev/negsoft-api/job"
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+globalArgs: []
+args: []
+
+env: []
+  # - name: MY_STATIC_VAR
+  #   value: "my_value"
+  # - name: MY_CONFIG_VAR
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: my-configmap
+  #       key: config-key
+  #       optional: false
+  # - name: MY_SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: secret-key
+  #       optional: false
+
+envFrom: []
+  # - configMapRef:
+  #     name: my-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: my-secret
+  #     optional: false
+
+secrets: []
+  # - name: cert-secret
+  #   secretName: my-certificate-secret
+  #   mountPath: /etc/certs
+  #   readOnly: true
+  #   optional: false
+
+configMaps: []
+  # - name: app-config
+  #   configMapName: my-app-config
+  #   mountPath: /etc/config
+  #   readOnly: true
+  #   optional: false
+
+# CSI-mounted secrets (Secrets Store CSI driver + Workload Identity): the pod's identity
+# fetches the secret from the cloud secret manager and mounts it as a file (never in etcd).
+# A container reads it from the mount path, e.g. via an *_FILE env var. Per-service specifics
+# (the SQL password secret + DATABASE_MSSQL_PASSWORD_FILE env) live in the deployment values.
+# Default off (empty).
+csiSecrets: []
+  # - name: my-secret
+  #   mountPath: /var/run/secret/my-secret
+  #   secretProviderClass: my-secret-provider
+  #   provider: gke
+  #   secrets:
+  #     - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
+  #       path: "my-secret-file"
+
+volume:
+  data:
+    volumeClaim: ""
+
+config: {}

--- a/charts/api-notification-deployment/.helmignore
+++ b/charts/api-notification-deployment/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/api-notification-deployment/Chart.yaml
+++ b/charts/api-notification-deployment/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: api-notification-deployment
+description: Deployment chart for the NegSoft notification WebSocket service
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.3.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/api-notification-deployment/templates/NOTES.txt
+++ b/charts/api-notification-deployment/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "api-notification-deployment.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "api-notification-deployment.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "api-notification-deployment.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "api-notification-deployment.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/api-notification-deployment/templates/_helpers.tpl
+++ b/charts/api-notification-deployment/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "api-notification-deployment.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "api-notification-deployment.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "api-notification-deployment.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "api-notification-deployment.labels" -}}
+helm.sh/chart: {{ include "api-notification-deployment.chart" . }}
+{{ include "api-notification-deployment.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "api-notification-deployment.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "api-notification-deployment.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "api-notification-deployment.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "api-notification-deployment.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/configmap.yaml
+++ b/charts/api-notification-deployment/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "api-notification-deployment.fullname" . }}
+data:
+  config.yaml: |-
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/api-notification-deployment/templates/deployment.yaml
+++ b/charts/api-notification-deployment/templates/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "api-notification-deployment.fullname" . }}
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "api-notification-deployment.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "api-notification-deployment.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "api-notification-deployment.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range .Values.globalArgs }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- range .Values.args }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metric
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- with .Values.config }}
+            - name: config
+              mountPath: /etc/nx
+              readOnly: true
+          {{- end }}
+          {{- range .Values.secrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.configMaps }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: true
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- with .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "api-notification-deployment.fullname" $ }}
+        {{- end }}
+        {{- range .Values.secrets }}
+        - name: {{ .name | quote }}
+          secret:
+            secretName: {{ .secretName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.configMaps }}
+        - name: {{ .name | quote }}
+          configMap:
+            name: {{ .configMapName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.csiSecrets }}
+        - name: {{ .name | quote }}
+          csi:
+            driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .secretProviderClass | quote }}
+        {{- end }}
+

--- a/charts/api-notification-deployment/templates/hpa.yaml
+++ b/charts/api-notification-deployment/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "api-notification-deployment.fullname" . }}
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "api-notification-deployment.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/ingress.yaml
+++ b/charts/api-notification-deployment/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "api-notification-deployment.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/pdb.yaml
+++ b/charts/api-notification-deployment/templates/pdb.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "api-notification-deployment.fullname" . }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end}}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end}}
+  selector:
+    matchLabels:
+      {{- include "api-notification-deployment.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/secretproviderclass.yaml
+++ b/charts/api-notification-deployment/templates/secretproviderclass.yaml
@@ -1,0 +1,19 @@
+{{- range $.Values.csiSecrets }}
+{{- if .secretProviderClass }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .secretProviderClass | quote }}
+  labels:
+    {{- include "api-notification-deployment.labels" $ | nindent 4 }}
+spec:
+  provider: {{ .provider | default "gke" }}
+  parameters:
+    secrets: |
+      {{- range .secrets }}
+      - resourceName: {{ .resourceName | quote }}
+        path: {{ .path | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/service.yaml
+++ b/charts/api-notification-deployment/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api-notification-deployment.fullname" . }}
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "api-notification-deployment.selectorLabels" . | nindent 4 }}

--- a/charts/api-notification-deployment/templates/serviceaccount.yaml
+++ b/charts/api-notification-deployment/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-notification-deployment.serviceAccountName" . }}
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/api-notification-deployment/templates/tests/test-connection.yaml
+++ b/charts/api-notification-deployment/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "api-notification-deployment.fullname" . }}-test-connection"
+  labels:
+    {{- include "api-notification-deployment.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "api-notification-deployment.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/api-notification-deployment/values.yaml
+++ b/charts/api-notification-deployment/values.yaml
@@ -1,0 +1,142 @@
+# Default values for notification.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/enthus-appdev/negsoft-api/notification
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podDisruptionBudget:
+  enabled: false
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+globalArgs: []
+args: []
+
+env: []
+  # - name: MY_STATIC_VAR
+  #   value: "my_value"
+  # - name: MY_CONFIG_VAR
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: my-configmap
+  #       key: config-key
+  #       optional: false
+  # - name: MY_SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: secret-key
+  #       optional: false
+
+envFrom: []
+  # - configMapRef:
+  #     name: my-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: my-secret
+  #     optional: false
+
+secrets: []
+  # - name: cert-secret
+  #   secretName: my-certificate-secret
+  #   mountPath: /etc/certs
+  #   readOnly: true
+  #   optional: false
+
+configMaps: []
+  # - name: app-config
+  #   configMapName: my-app-config
+  #   mountPath: /etc/config
+  #   readOnly: true
+  #   optional: false
+
+# CSI-mounted secrets (Secrets Store CSI driver + Workload Identity): the pod's identity
+# fetches the secret from the cloud secret manager and mounts it as a file (never in etcd).
+# A container reads it from the mount path, e.g. via an *_FILE env var. Per-service specifics
+# (the SQL password secret + DATABASE_MSSQL_PASSWORD_FILE env) live in the deployment values.
+# Default off (empty).
+csiSecrets: []
+  # - name: my-secret
+  #   mountPath: /var/run/secret/my-secret
+  #   secretProviderClass: my-secret-provider
+  #   provider: gke
+  #   secrets:
+  #     - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
+  #       path: "my-secret-file"
+
+config: {}

--- a/charts/api-portal-deployment/.helmignore
+++ b/charts/api-portal-deployment/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/api-portal-deployment/Chart.yaml
+++ b/charts/api-portal-deployment/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: api-portal-deployment
+description: Deployment chart for the NegSoft Portal (customer-facing) API service
+type: application
+version: 0.4.0
+appVersion: "1.0.0"
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/api-portal-deployment/templates/NOTES.txt
+++ b/charts/api-portal-deployment/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $.Values.ingress.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "api-portal-deployment.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "api-portal-deployment.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "api-portal-deployment.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "api-portal-deployment.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/api-portal-deployment/templates/_helpers.tpl
+++ b/charts/api-portal-deployment/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "api-portal-deployment.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "api-portal-deployment.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "api-portal-deployment.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "api-portal-deployment.labels" -}}
+app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+helm.sh/chart: {{ include "api-portal-deployment.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "api-portal-deployment.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "api-portal-deployment.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/api-portal-deployment/templates/configmap.yaml
+++ b/charts/api-portal-deployment/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "api-portal-deployment.fullname" $ }}
+data:
+  config.yaml: |-
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/api-portal-deployment/templates/deployment.yaml
+++ b/charts/api-portal-deployment/templates/deployment.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "api-portal-deployment.fullname" . }}
+  labels:
+{{ include "api-portal-deployment.labels" . | indent 4 }}
+    mcl.sh/name: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      mcl.sh/name: {{ .Chart.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        mcl.sh/name: {{ .Chart.Name }}
+    spec:
+    {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "api-portal-deployment.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- range .Values.args }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metric
+              containerPort: 8081
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: files
+              mountPath: /mnt/files
+          {{- with .Values.config }}
+            - name: config
+              mountPath: /etc/nx
+              readOnly: true
+          {{- end }}
+          {{- range .Values.secrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.configMaps }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: {{ .readOnly | default true }}
+          {{- end }}
+          {{- range .Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: true
+          {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      volumes:
+      {{- with .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "api-portal-deployment.fullname" $ }}
+      {{- end }}
+        - name: files
+        {{- if .Values.volume.data.volumeClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.volume.data.volumeClaim }}
+        {{- end }}
+        {{- range .Values.secrets }}
+        - name: {{ .name | quote }}
+          secret:
+            secretName: {{ .secretName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.configMaps }}
+        - name: {{ .name | quote }}
+          configMap:
+            name: {{ .configMapName | quote }}
+            optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.csiSecrets }}
+        - name: {{ .name | quote }}
+          csi:
+            driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .secretProviderClass | quote }}
+        {{- end }}
+  {{- with .Values.additionalSpecs }}
+    {{ toYaml . | nindent 2 }}
+  {{- end }}

--- a/charts/api-portal-deployment/templates/ingress.yaml
+++ b/charts/api-portal-deployment/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "api-portal-deployment.fullname" . -}}
+{{- $ingressPaths := .Values.ingress.paths -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+    helm.sh/chart: {{ include "api-portal-deployment.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+	{{- range $ingressPaths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+	{{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/api-portal-deployment/templates/pdb.yaml
+++ b/charts/api-portal-deployment/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "api-portal-deployment.fullname" . }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end}}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      mcl.sh/name: {{ .Chart.Name }}
+{{- end }}

--- a/charts/api-portal-deployment/templates/secretproviderclass.yaml
+++ b/charts/api-portal-deployment/templates/secretproviderclass.yaml
@@ -1,0 +1,19 @@
+{{- range $.Values.csiSecrets }}
+{{- if .secretProviderClass }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .secretProviderClass | quote }}
+  labels:
+    {{- include "api-portal-deployment.labels" $ | nindent 4 }}
+spec:
+  provider: {{ .provider | default "gke" }}
+  parameters:
+    secrets: |
+      {{- range .secrets }}
+      - resourceName: {{ .resourceName | quote }}
+        path: {{ .path | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/api-portal-deployment/templates/service.yaml
+++ b/charts/api-portal-deployment/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api-portal-deployment.fullname" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+    helm.sh/chart: {{ include "api-portal-deployment.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/api-portal-deployment/templates/serviceaccount.yaml
+++ b/charts/api-portal-deployment/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "api-portal-deployment.serviceAccountName" . }}
+  labels:
+    {{- include "api-portal-deployment.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/api-portal-deployment/templates/tests/test-connection.yaml
+++ b/charts/api-portal-deployment/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "api-portal-deployment.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "api-portal-deployment.name" . }}
+    helm.sh/chart: {{ include "api-portal-deployment.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "api-portal-deployment.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/api-portal-deployment/values.yaml
+++ b/charts/api-portal-deployment/values.yaml
@@ -1,0 +1,130 @@
+# Default values for myapi.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/enthus-appdev/negsoft-api/portal
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+  #  - name: pull-secret
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  paths: []
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+podAnnotations: {}
+
+additionalSpecs: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: ""
+
+podDisruptionBudget:
+  enabled: false
+  #  minAvailable: 50%
+  #  maxUnavailable: 50%
+
+extraArgs: []
+args: []
+
+env: []
+  # - name: MY_STATIC_VAR
+  #   value: "my_value"
+  # - name: MY_CONFIG_VAR
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: my-configmap
+  #       key: config-key
+  #       optional: false
+  # - name: MY_SECRET_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: secret-key
+  #       optional: false
+
+envFrom: []
+  # - configMapRef:
+  #     name: my-configmap
+  #     optional: false
+  # - secretRef:
+  #     name: my-secret
+  #     optional: false
+
+secrets: []
+  # - name: cert-secret
+  #   secretName: my-certificate-secret
+  #   mountPath: /etc/certs
+  #   readOnly: true
+  #   optional: false
+
+configMaps: []
+  # - name: app-config
+  #   configMapName: my-app-config
+  #   mountPath: /etc/config
+  #   readOnly: true
+  #   optional: false
+
+# CSI-mounted secrets (Secrets Store CSI driver + Workload Identity): the pod's identity
+# fetches the secret from the cloud secret manager and mounts it as a file (never in etcd).
+# A container reads it from the mount path, e.g. via an *_FILE env var. Per-service specifics
+# (the SQL password secret + DATABASE_MSSQL_PASSWORD_FILE env) live in the deployment values.
+# Default off (empty).
+csiSecrets: []
+  # - name: my-secret
+  #   mountPath: /var/run/secret/my-secret
+  #   secretProviderClass: my-secret-provider
+  #   provider: gke
+  #   secrets:
+  #     - resourceName: "projects/my-project/secrets/my-secret/versions/latest"
+  #       path: "my-secret-file"
+
+volume:
+  data:
+    volumeClaim: ""
+
+config: {}


### PR DESCRIPTION
## What & Why

Migrates four service Helm charts out of the `negsoft-api` repo into this shared chart repo, continuing the consolidation already started with `api-deployment`, `api-subscription`, and `healthcheck`. The `negsoft-api` deploy workflow will switch to consuming these as `enthus-charts/<name>` in a follow-up PR (gated on these being published).

Charts are named with the `api-` prefix to match the existing `api-deployment` / `api-subscription` charts (both from the api repo), and the suffix reflects the deployed **service/image** rather than the old local directory name:

| `negsoft-api/charts/` | → this repo | deploys |
|---|---|---|
| `myapi` | `api-portal-deployment` | `…/portal` image (customer-facing API) |
| `manager` | `api-manager-deployment` | `…/manager` image |
| `notification` | `api-notification-deployment` | `…/notification` image (WebSocket) |
| `cron` | `api-job-cronjob` | `…/job` image, as CronJobs |

`api` (the main `…/http` deployment) is intentionally **not** included — it needs a separate reconciliation against the existing (drifted/stale) `api-deployment` chart.

## Key Changes

- Four charts copied in, `Chart.yaml` aligned to repo style (`apiVersion: v2`, `type: application`, `enthus GmbH` maintainer, real descriptions).
- Helper-template prefixes renamed per chart (e.g. `myapi.fullname` → `api-portal-deployment.fullname`) so rendered labels/names match — same approach as the earlier `api` → `api-deployment` migration.
- README "Available charts" table updated.

## Testing

`helm lint` and `helm template` pass clean for all four charts (only the cosmetic `icon is recommended` info, shared by existing charts). Rendered `helm.sh/chart` labels confirmed to use the new names.

## Deployment Notes

Once merged, chart-releaser publishes the four new charts to Pages. Only **after** that can the follow-up `negsoft-api` PR flip its workflow refs (`./charts/{myapi,manager,cron,notification}` → `enthus-charts/{api-portal-deployment,api-manager-deployment,api-notification-deployment,api-job-cronjob}`) and delete the local copies.