### PR TITLE
feat: add optional redisPassword to negsoft-operator chart

### DIFF
--- a/charts/negsoft-operator/Chart.yaml
+++ b/charts/negsoft-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/negsoft-operator/templates/deployment.yaml
+++ b/charts/negsoft-operator/templates/deployment.yaml
@@ -78,6 +78,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "negsoft-operator.fullname" . }}-secret
                   key: redisDatabase
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: redisPassword
             - name: CRONJOB_PREFIX
               value: {{ .Values.cronjobPrefix }}
           volumeMounts:

--- a/charts/negsoft-operator/templates/secret.yaml
+++ b/charts/negsoft-operator/templates/secret.yaml
@@ -13,3 +13,4 @@ data:
   redisAddresses: {{ .Values.secret.redisAddresses | b64enc | quote }}
   redisMasterSet: {{ .Values.secret.redisMasterSet | b64enc | quote }}
   redisDatabase: {{ .Values.secret.redisDatabase | b64enc | quote }}
+  redisPassword: {{ .Values.secret.redisPassword | default "" | b64enc | quote }}


### PR DESCRIPTION
## What & Why

ew4 Redis has `requirepass` enabled, but the `negsoft-operator` chart had no way to pass a Redis password. Adds an optional `secret.redisPassword` → rendered into the chart Secret and injected as the `REDIS_PASSWORD` env var.

## Key Changes
- `secret.yaml`: `redisPassword` key (`default ""` → backward-compatible; empty = no auth, as on ew3).
- `deployment.yaml`: `REDIS_PASSWORD` env from the same Secret.
- `Chart.yaml`: 0.2.1 → 0.3.0.

## Testing
`helm template` renders the Secret key + env; existing deployments unaffected (empty default).

Consumed by negsoft-subscription-operator's ew4 values (separate PR) — merge this first.