### PR TITLE
feat: NX-15715 portal credentials passthrough for health check (chart 0.2.0)

### DIFF
--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: healthcheck
 description: In-cluster post-deploy health-check probe (browser render + API + live-query round-trip) that reports red/green to Discord.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "1.0"
 maintainers:
   - name: "enthus GmbH"

--- a/charts/healthcheck/templates/_helpers.tpl
+++ b/charts/healthcheck/templates/_helpers.tpl
@@ -119,6 +119,23 @@ containers:
             key: {{ $discord.webhookSecretKey | default "webhook-url" | quote }}
             optional: false
       {{- end }}
+      {{- $portal := .Values.portal | default dict }}
+      - name: PORTAL_API_BASE
+        value: {{ $portal.apiBase | default "" | quote }}
+      {{- if $portal.credentialsSecretName }}
+      - name: PORTAL_EMAIL
+        valueFrom:
+          secretKeyRef:
+            name: {{ $portal.credentialsSecretName | quote }}
+            key: {{ $portal.credentialsEmailKey | default "email" | quote }}
+            optional: false
+      - name: PORTAL_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ $portal.credentialsSecretName | quote }}
+            key: {{ $portal.credentialsPasswordKey | default "password" | quote }}
+            optional: false
+      {{- end }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}
     volumeMounts:

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -50,6 +50,19 @@ discord:
   webhookSecretName: ""
   webhookSecretKey: webhook-url
 
+# Portal (customer-facing) health check. Separate customer identity from the
+# employee flow: a real login with credentials from a Secret (never templated).
+# Runs only when apiBase AND the credentials Secret are both set; otherwise the
+# probe skips the portal checks. Set per environment.
+portal:
+  # Portal Go API ClusterIP service base (e.g. http://api-portal.<ns>.svc:8080).
+  apiBase: ""
+  # Kubernetes Secret holding the monitor customer's portal login (created
+  # out-of-band, never templated). Keys default to email / password.
+  credentialsSecretName: ""
+  credentialsEmailKey: email
+  credentialsPasswordKey: password
+
 # Ambient schedule. "" disables the CronJob (e.g. environments that scale to
 # zero outside work hours and run only on deploy).
 schedule: ""


### PR DESCRIPTION
## What & Why

Adds a `portal` value group to the `healthcheck` chart so the probe can run a **customer-facing portal flow** (real customer login + SQL-backed data read) alongside the existing employee GUI/API/legacy checks.

The chart stays a pure passthrough — no probe/auth logic here (that lives in the private `negsoft-healthcheck` probe). This PR only wires config → env.

## Key Changes

- `portal.apiBase` → `PORTAL_API_BASE` (portal Go API ClusterIP base). Empty → the probe skips the portal flow.
- `portal.credentialsSecretName` → `PORTAL_EMAIL` / `PORTAL_PASSWORD` via `secretKeyRef` (keys default `email`/`password`), mounted from a Secret provisioned out-of-band — **never templated through values**, same pattern as the Discord webhook secret.
- Chart **0.1.0 → 0.2.0** (chart-releaser requires a version bump on chart change).

## Backward compatibility

Envs without a portal leave the group empty: only an empty `PORTAL_API_BASE` is emitted (no secret refs), and the probe skips portal checks. Verified via `helm template` with and without `portal.*` set; `helm lint` clean.

## Companion PRs

- Probe portal flow + stage values: `enthus-appdev/negsoft-healthcheck#4`.
- Deploying portal to an env additionally needs the caller to pin `chart_version: 0.2.0` (follow-up, same adoption pattern as the replica/ew4 work).