### PR TITLE
feat: NX-15696 add optional mssqlDatabase to negsoft-operator chart (0.5.0)

### DIFF
--- a/charts/negsoft-operator/Chart.yaml
+++ b/charts/negsoft-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/negsoft-operator/templates/deployment.yaml
+++ b/charts/negsoft-operator/templates/deployment.yaml
@@ -53,6 +53,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "negsoft-operator.fullname" . }}-secret
                   key: mssqlPort
+            - name: MSSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "negsoft-operator.fullname" . }}-secret
+                  key: mssqlDatabase
             - name: MSSQL_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/negsoft-operator/templates/deployment.yaml
+++ b/charts/negsoft-operator/templates/deployment.yaml
@@ -53,11 +53,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "negsoft-operator.fullname" . }}-secret
                   key: mssqlPort
+            {{- if .Values.secret.mssqlDatabase }}
             - name: MSSQL_DATABASE
               valueFrom:
                 secretKeyRef:
                   name: {{ include "negsoft-operator.fullname" . }}-secret
                   key: mssqlDatabase
+            {{- end }}
             - name: MSSQL_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/negsoft-operator/templates/secret.yaml
+++ b/charts/negsoft-operator/templates/secret.yaml
@@ -8,7 +8,9 @@ type: Opaque
 data:
   mssqlHostname: {{ .Values.secret.mssqlHostname | b64enc | quote }}
   mssqlPort: {{ .Values.secret.mssqlPort | b64enc | quote }}
-  mssqlDatabase: {{ .Values.secret.mssqlDatabase | default "" | b64enc | quote }}
+  {{- if .Values.secret.mssqlDatabase }}
+  mssqlDatabase: {{ .Values.secret.mssqlDatabase | b64enc | quote }}
+  {{- end }}
   mssqlUsername: {{ .Values.secret.mssqlUsername | b64enc | quote }}
   mssqlPassword: {{ .Values.secret.mssqlPassword | b64enc | quote }}
   redisAddresses: {{ .Values.secret.redisAddresses | b64enc | quote }}

--- a/charts/negsoft-operator/templates/secret.yaml
+++ b/charts/negsoft-operator/templates/secret.yaml
@@ -8,6 +8,7 @@ type: Opaque
 data:
   mssqlHostname: {{ .Values.secret.mssqlHostname | b64enc | quote }}
   mssqlPort: {{ .Values.secret.mssqlPort | b64enc | quote }}
+  mssqlDatabase: {{ .Values.secret.mssqlDatabase | default "" | b64enc | quote }}
   mssqlUsername: {{ .Values.secret.mssqlUsername | b64enc | quote }}
   mssqlPassword: {{ .Values.secret.mssqlPassword | b64enc | quote }}
   redisAddresses: {{ .Values.secret.redisAddresses | b64enc | quote }}

--- a/charts/negsoft-operator/values.yaml
+++ b/charts/negsoft-operator/values.yaml
@@ -103,6 +103,7 @@ affinity: {}
 secret:
   mssqlHostname: ""
   mssqlPort: "1433"
+  mssqlDatabase: ""
   mssqlUsername: ""
   mssqlPassword: ""
   redisAddresses: ""


### PR DESCRIPTION
## What & Why

The subscription operator's `getMSSQLConnection` builds its DSN with **no database**, so on Azure SQL MI the per-service `nx_subscription` login defaults to `master` — which has no change tracking and no `sao.*` tables. The operator then logs:

```
get change tracking version: sql: Scan error ... converting NULL to int64 is unsupported
```

(`CHANGE_TRACKING_CURRENT_VERSION()` is NULL in `master`.) On the old server the shared login defaulted to the app DB, so this never surfaced.

This wires an **optional** `MSSQL_DATABASE` env (secret-backed, default empty) so prod can pin the connection to `NegSoft_Productive` — the same inject-the-database approach used for the Go services, not patching the login's default database.

## Key Changes
- `secret.yaml`: add `mssqlDatabase` key.
- `deployment.yaml`: add `MSSQL_DATABASE` env from that key.
- `values.yaml`: `secret.mssqlDatabase: ""` (empty → operator keeps the login default, preserving stage/old-server behaviour).
- Chart `0.4.0` → `0.5.0`.

## Testing
`helm lint` clean; `helm template --set secret.mssqlDatabase=NegSoft_Productive` renders the env + secret key.

## Deployment Notes
Pairs with the operator code change (read `MSSQL_DATABASE` into the DSN) and the prod values setting `mssqlDatabase: NegSoft_Productive`. Empty default keeps stage unchanged.