### PR TITLE
fix: NX-15696 mount csiSecrets in the api-manager job template (0.6.0)

### DIFF
--- a/charts/api-manager-deployment/Chart.yaml
+++ b/charts/api-manager-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-manager-deployment/templates/job.yaml
+++ b/charts/api-manager-deployment/templates/job.yaml
@@ -66,6 +66,11 @@ spec:
               mountPath: {{ .mountPath | quote }}
               readOnly: {{ .readOnly | default true }}
           {{- end }}
+          {{- range .Values.csiSecrets }}
+            - name: {{ .name | quote }}
+              mountPath: {{ .mountPath | quote }}
+              readOnly: true
+          {{- end }}
       {{- with .Values.job.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
@@ -102,6 +107,14 @@ spec:
           configMap:
             name: {{ .configMapName | quote }}
             optional: {{ .optional | default false }}
+        {{- end }}
+        {{- range .Values.csiSecrets }}
+        - name: {{ .name | quote }}
+          csi:
+            driver: {{ .driver | default "secrets-store-gke.csi.k8s.io" }}
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .secretProviderClass | quote }}
         {{- end }}
       restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
## What & Why

`api-manager` consumes `nx-prod-core-job` and spawns a Kubernetes Job (the `api-job`) per request. On ew4 the manager Deployment was migrated to Secrets Store CSI file-mounts (`.Values.csiSecrets` → `/var/run/secret/sql/password` etc.), but the **Job template was left behind** — it injects `.Values.env` (so the Job gets `DATABASE_MSSQL_PASSWORD_FILE=/var/run/secret/sql/password`) yet never mounts `.Values.csiSecrets`. Result: every spawned Job panics —

```
failed to read DATABASE_MSSQL_PASSWORD_FILE from /var/run/secret/sql/password: no such file or directory
```

(observed when an XLSX export was triggered — manager spawned the Job, the Job crash-looped to `backoffLimit`).

## Key Changes
- `templates/job.yaml`: add the `.Values.csiSecrets` volumeMounts + CSI volumes, mirroring `deployment.yaml`. The Job reuses the same `SecretProviderClass`es the manager already creates.
- Chart `0.5.0` → `0.6.0`.

## Testing
`helm lint` clean; `helm template -f values-manager.yaml` now renders the `api-manager-sql` / `api-manager-redis` CSI volumes + the `/var/run/secret/sql` mount inside `template_job.yaml`.

## Deployment Notes
- Pairs with the negsoft-api change setting `job.serviceAccountName: api-manager` so the Job runs under the SA that can fetch those secrets (the default `api-cron` SA isn't granted them).
- After publish, redeploy `api-manager` and re-trigger the export.