### PR TITLE
feat: NX-15696 add entpdf chart (PDF/A-3 ZUGFeRD converter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ helm install my-release enthus/<chart-name>
 | [api-portal-deployment](charts/api-portal-deployment) | Deployment chart for the NegSoft Portal (customer-facing) API service |
 | [api-subscription](charts/api-subscription) | Deployment chart for the NegSoft subscription API workload |
 | [default](charts/default) | Default chart scaffold from `helm create` |
+| [entpdf](charts/entpdf) | PDF/A-3 converter for ZUGFeRD/Factur-X e-invoices (PDF2PDFA replacement) |
 | [negsoft-operator](charts/negsoft-operator) | Kubernetes operator for managing NegSoft user subscriptions |
 | [nexus](charts/nexus) | Internal admin UI for database operations, configuration, and cross-environment replication |
 | [pim-cronjob](charts/pim-cronjob) | Reusable Kubernetes CronJob chart for Product Information Management (PIM) workloads — importers, exporters, and generators |

--- a/charts/entpdf/Chart.yaml
+++ b/charts/entpdf/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: entpdf
+description: PDF/A-3 converter for ZUGFeRD/Factur-X e-invoices (PDF2PDFA replacement). Stateless FastAPI service called in-cluster by the NegSoft API.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+maintainers:
+  - name: "enthus GmbH"

--- a/charts/entpdf/templates/NOTES.txt
+++ b/charts/entpdf/templates/NOTES.txt
@@ -1,0 +1,13 @@
+{{ include "entpdf.fullname" . }} deployed.
+
+Internal endpoint (ClusterIP, same namespace):
+  http://{{ include "entpdf.fullname" . }}:{{ .Values.service.port }}
+
+Fully qualified:
+  http://{{ include "entpdf.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Point the NegSoft API config key EntPDFHTTPAddress at that URL.
+
+Health check:
+  kubectl -n {{ .Release.Namespace }} run curl --rm -it --image=curlimages/curl --restart=Never -- \
+    curl -fsS http://{{ include "entpdf.fullname" . }}:{{ .Values.service.port }}/health

--- a/charts/entpdf/templates/_helpers.tpl
+++ b/charts/entpdf/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "entpdf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "entpdf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "entpdf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "entpdf.labels" -}}
+helm.sh/chart: {{ include "entpdf.chart" . }}
+{{ include "entpdf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "entpdf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "entpdf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "entpdf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "entpdf.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/entpdf/templates/deployment.yaml
+++ b/charts/entpdf/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "entpdf.fullname" . }}
+  labels:
+    {{- include "entpdf.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: {{ .Values.podStrategyType }}
+  selector:
+    matchLabels:
+      {{- include "entpdf.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "entpdf.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "entpdf.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: {{ .Values.containerPort | quote }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/entpdf/templates/hpa.yaml
+++ b/charts/entpdf/templates/hpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "entpdf.fullname" . }}
+  labels:
+    {{- include "entpdf.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "entpdf.fullname" . }}
+  {{- toYaml .Values.autoscaling.config | nindent 2 }}
+{{- end }}

--- a/charts/entpdf/templates/pdb.yaml
+++ b/charts/entpdf/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "entpdf.fullname" . }}
+  labels:
+    {{- include "entpdf.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "entpdf.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/entpdf/templates/service.yaml
+++ b/charts/entpdf/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "entpdf.fullname" . }}
+  labels:
+    {{- include "entpdf.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "entpdf.selectorLabels" . | nindent 4 }}

--- a/charts/entpdf/templates/serviceaccount.yaml
+++ b/charts/entpdf/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "entpdf.serviceAccountName" . }}
+  labels:
+    {{- include "entpdf.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/entpdf/values.yaml
+++ b/charts/entpdf/values.yaml
@@ -1,0 +1,108 @@
+# Default values for entpdf.
+# entpdf is a stateless PDF/A-3 converter (FastAPI). Its production path
+# (POST /convert-pdf) is pure pikepdf and has no external dependencies. The
+# HTML path (POST /generate-pdf) needs Gotenberg, which the NegSoft API does
+# NOT use, so GOTENBERG_URL is left unset by default.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/enthus-appdev/entpdf
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # entpdf accesses no GCP resources, so no Workload Identity annotation is needed.
+  create: true
+  annotations: {}
+  name: ""
+
+podStrategyType: RollingUpdate
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+podAnnotations: {}
+podLabels: {}
+
+# The container runs rootless (uid 1000) with a read-only root filesystem;
+# /tmp is provided as an emptyDir for veraPDF scratch files.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 8000
+
+# Container listen port (uvicorn). Set via the PORT env below as well.
+containerPort: 8000
+
+# Environment variables passed to the container. WORKERS stays at 1 because
+# Prometheus metrics use the per-process default registry; scale via replicas.
+env:
+  - name: WORKERS
+    value: "1"
+
+# Extra raw env entries (valueFrom, etc.) appended verbatim.
+extraEnv: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+autoscaling:
+  enabled: true
+  config:
+    minReplicas: 2
+    maxReplicas: 6
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 70
+
+# Node scheduling. Empty by default: a 24/7 service lands on the untainted
+# np-services pool. Set tolerations/nodeSelector only for the Spot pools.
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/entpdf/values.yaml
+++ b/charts/entpdf/values.yaml
@@ -1,8 +1,6 @@
 # Default values for entpdf.
-# entpdf is a stateless PDF/A-3 converter (FastAPI). Its production path
-# (POST /convert-pdf) is pure pikepdf and has no external dependencies. The
-# HTML path (POST /generate-pdf) needs Gotenberg, which the NegSoft API does
-# NOT use, so GOTENBERG_URL is left unset by default.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
 
 replicaCount: 2
 
@@ -17,9 +15,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # entpdf accesses no GCP resources, so no Workload Identity annotation is needed.
+  # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account
   annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podStrategyType: RollingUpdate
@@ -31,8 +32,6 @@ podDisruptionBudget:
 podAnnotations: {}
 podLabels: {}
 
-# The container runs rootless (uid 1000) with a read-only root filesystem;
-# /tmp is provided as an emptyDir for veraPDF scratch files.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
@@ -53,16 +52,12 @@ service:
   type: ClusterIP
   port: 8000
 
-# Container listen port (uvicorn). Set via the PORT env below as well.
 containerPort: 8000
 
-# Environment variables passed to the container. WORKERS stays at 1 because
-# Prometheus metrics use the per-process default registry; scale via replicas.
 env:
   - name: WORKERS
     value: "1"
 
-# Extra raw env entries (valueFrom, etc.) appended verbatim.
 extraEnv: []
 
 resources:
@@ -101,8 +96,6 @@ autoscaling:
             type: Utilization
             averageUtilization: 70
 
-# Node scheduling. Empty by default: a 24/7 service lands on the untainted
-# np-services pool. Set tolerations/nodeSelector only for the Spot pools.
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Dedicated chart for the **entpdf** service (the PDF2PDFA replacement, repo [`enthus-appdev/entpdf`](https://github.com/enthus-appdev/entpdf)), deployed in-cluster on ew4 (`mts` namespace) and called by the NegSoft API for ZUGFeRD invoices.

## Why a new chart (not `api-deployment`)

`api-deployment` is bound to the Go API: hard-coded `containerPort: 8080`, probe path `/`, and a mandatory `/mnt/files` mount. entpdf needs `/health` probes on its own port and none of the DB/file plumbing. The repo convention is one chart per service, so this follows `nexus`/`api-*`.

## Contents

- Stateless **Deployment + ClusterIP Service + ServiceAccount + HPA + PDB**
- `/health` liveness/readiness probes (configurable), port 8000
- Rootless `securityContext` (uid 1000, read-only root fs, cap-drop ALL, seccomp RuntimeDefault) + `/tmp` emptyDir for veraPDF scratch
- Templated `nodeSelector`/`tolerations`/`affinity` (empty by default → untainted `np-services` pool)
- No database, secrets, or Gotenberg dependency — the API only uses `POST /convert-pdf`, which is pure pikepdf

## Validation

`helm lint` clean; `helm template` + server-side dry-run against `gke-mts-prod-euw4-01` validated. Already deployed to `mts` and verified: `/convert-pdf` returns a veraPDF-compliant PDF/A-3 (0 failed checks).