### PR TITLE
feat(nexus): add env passthrough for _FILE secret mounts

### DIFF
--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nexus/templates/deployment.yaml
+++ b/charts/nexus/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /_healthcheck

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -79,6 +79,13 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# Additional container environment variables. Useful for the `_FILE`
+# convention: point an app setting at a CSI-mounted secret file rather than
+# baking the value into config.
+env: []
+# - name: DATABASE_PRODUCTIVE_PASSWORD_FILE
+#   value: /config/productive-password
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo


### PR DESCRIPTION
## Why
The `nexus` chart exposed no way to set container environment variables. The `_FILE` secret convention needs them — an app setting points at a CSI-mounted secret file instead of baking the value into config.

Required by tool-nexus, which splits its SQL passwords into per-environment Secret Manager secrets (CAF / secret-manager rules) and reads them via `DATABASE_*_PASSWORD_FILE`. See the enthus-appdev/tool-nexus PR.

## What
- Generic `env: []` passthrough in `values.yaml` + `deployment.yaml` (backward compatible; default empty)
- Chart `0.5.1` → `0.6.0`

## Notes
Needs a chart **release** so consumers can pin `--version 0.6.0`.