### PR TITLE
chore: make all chart image defaults consistent (GHCR-direct)

### DIFF
--- a/charts/api-deployment/Chart.yaml
+++ b/charts/api-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: registry.gitlab.com/mcldev/negsoft/api
+  repository: ghcr.io/enthus-appdev/negsoft-api/http
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/api-subscription/Chart.yaml
+++ b/charts/api-subscription/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-subscription/values.yaml
+++ b/charts/api-subscription/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: nginx
+  repository: ghcr.io/enthus-appdev/negsoft-api/job
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/charts/healthcheck/Chart.yaml
+++ b/charts/healthcheck/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: healthcheck
 description: In-cluster post-deploy health-check probe (browser render + API + live-query round-trip) that reports red/green to Discord.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0"
 maintainers:
   - name: "enthus GmbH"

--- a/charts/healthcheck/values.yaml
+++ b/charts/healthcheck/values.yaml
@@ -6,10 +6,11 @@
 # supplies a values file.
 
 # Probe image (private — pulled in-cluster). Pin a sha-<commit> tag per
-# environment for reproducibility; `latest` is only the placeholder default.
+# environment for reproducibility.
 image:
-  repository: europe-west3-docker.pkg.dev/mcl-development/ghcr-enthus-appdev-remote/enthus-appdev/negsoft-healthcheck
-  tag: latest
+  repository: ghcr.io/enthus-appdev/negsoft-healthcheck
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/charts/negsoft-operator/Chart.yaml
+++ b/charts/negsoft-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/negsoft-operator/values.yaml
+++ b/charts/negsoft-operator/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: nginx
+  repository: ghcr.io/enthus-appdev/negsoft-subscription-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/nexus/Chart.yaml
+++ b/charts/nexus/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: registry.gitlab.com/mcldev/negsoft/nexus
+  repository: ghcr.io/enthus-appdev/tool-nexus
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Several charts in this **public** repo had non-standard `image.repository` defaults: two pointed at the retired GitLab group, one at the Artifact Registry mirror (leaking the `mcl-development` project), and two still had the `nginx` helm-create placeholder. This makes every real-service chart use the same GHCR-direct convention — `ghcr.io/enthus-appdev/<repo>[/<service>]` — already used by the api-* charts and entpdf.

## Changes

| Chart | Old default | New default |
|-------|-------------|-------------|
| `api-deployment` | `registry.gitlab.com/mcldev/negsoft/api` | `ghcr.io/enthus-appdev/negsoft-api/http` |
| `nexus` | `registry.gitlab.com/mcldev/negsoft/nexus` | `ghcr.io/enthus-appdev/tool-nexus` |
| `healthcheck` | `europe-west3-docker.pkg.dev/mcl-development/…/negsoft-healthcheck` (`tag: latest`) | `ghcr.io/enthus-appdev/negsoft-healthcheck` (`tag: ""`) |
| `negsoft-operator` | `nginx` | `ghcr.io/enthus-appdev/negsoft-subscription-operator` |
| `api-subscription` | `nginx` | `ghcr.io/enthus-appdev/negsoft-api/job` |

Each new path is the image the chart actually runs, verified against the live `mts` cluster (and the `tool-nexus` build workflow). `api-subscription` produces a `NegSoftSubscription` CR whose `imageRepository` the operator uses to spawn `negsoft-api/job` cronjobs.

Left as-is: `default` (the `helm create` scaffold) and `pim-cronjob` (a reusable template with an intentionally empty, must-override repository).

## Safety

`image.repository` is **always overridden** at deploy time from the private deploy values, so **no running workload changes** — this only fixes the chart defaults and removes the last GitLab / Artifact-Registry / `mcl-development` references from the public repo. All affected chart versions bumped so chart-releaser publishes. `helm lint` clean; rendered images resolve to the GHCR paths.