### PR TITLE
feat: api-deployment scaleToZero block (IngressRoute + HTTPScaledObject)

### DIFF
--- a/charts/api-deployment/Chart.yaml
+++ b/charts/api-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-deployment/templates/_helpers.tpl
+++ b/charts/api-deployment/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Fail fast on conflicting or incomplete scaleToZero config.
+*/}}
+{{- define "api-deployment.scaleToZero.validate" -}}
+{{- if .Values.scaleToZero.enabled -}}
+{{- if not .Values.scaleToZero.hosts }}{{ fail "scaleToZero.enabled requires scaleToZero.hosts" }}{{- end -}}
+{{- if .Values.ingress.enabled }}{{ fail "scaleToZero and ingress are mutually exclusive — disable ingress" }}{{- end -}}
+{{- if .Values.autoscaling.enabled }}{{ fail "scaleToZero scales replicas via KEDA — disable autoscaling (HPA)" }}{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
+++ b/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.scaleToZero.enabled .Values.scaleToZero.hosts }}
+{{- $fullName := include "api-deployment.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "api-deployment.labels" . | nindent 4 }}
+spec:
+  hosts:
+    {{- toYaml $stz.hosts | nindent 4 }}
+  scaledownPeriod: {{ $stz.scaledownPeriod | default 300 }}
+  scalingMetric:
+    concurrency:
+      targetValue: {{ $stz.targetConcurrency | default 10 }}
+  scaleTargetRef:
+    name: {{ $fullName }}
+    kind: Deployment
+    apiVersion: apps/v1
+    service: {{ $fullName }}
+    port: {{ .Values.service.port }}
+  replicas:
+    min: {{ $stz.minReplicas | default 0 }}
+    max: {{ $stz.maxReplicas | default 1 }}
+{{- end }}

--- a/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
+++ b/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.scaleToZero.enabled .Values.scaleToZero.hosts }}
+{{- if .Values.scaleToZero.enabled }}
+{{- include "api-deployment.scaleToZero.validate" . }}
 {{- $fullName := include "api-deployment.fullname" . -}}
 {{- $stz := .Values.scaleToZero -}}
 kind: HTTPScaledObject

--- a/charts/api-deployment/templates/scaletozero-ingressroute.yaml
+++ b/charts/api-deployment/templates/scaletozero-ingressroute.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.scaleToZero.enabled .Values.scaleToZero.hosts }}
+{{- $fullName := include "api-deployment.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+# Cross-namespace service ref → requires Traefik providers.kubernetesCRD.allowCrossNamespace=true.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}-interceptor
+  {{- with $stz.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "api-deployment.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $stz.entryPoint | default "websecure" }}
+  routes:
+    {{- range $stz.hosts }}
+    - match: Host(`{{ . }}`){{- range $stz.excludePathPrefixes }} && !PathPrefix(`{{ . }}`){{- end }}
+      kind: Rule
+      services:
+        - name: {{ required "scaleToZero.interceptor.name is required" $stz.interceptor.name }}
+          namespace: {{ required "scaleToZero.interceptor.namespace is required" $stz.interceptor.namespace }}
+          port: {{ $stz.interceptor.port | default 8080 }}
+    {{- end }}
+{{- end }}

--- a/charts/api-deployment/templates/scaletozero-ingressroute.yaml
+++ b/charts/api-deployment/templates/scaletozero-ingressroute.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.scaleToZero.enabled .Values.scaleToZero.hosts }}
+{{- if .Values.scaleToZero.enabled }}
+{{- include "api-deployment.scaleToZero.validate" . }}
 {{- $fullName := include "api-deployment.fullname" . -}}
 {{- $stz := .Values.scaleToZero -}}
 # Cross-namespace service ref → requires Traefik providers.kubernetesCRD.allowCrossNamespace=true.

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -62,6 +62,24 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Request-driven scale-to-zero via the KEDA HTTP add-on. Needs Traefik
+# providers.kubernetesCRD.allowCrossNamespace=true; disable `ingress` when enabling.
+scaleToZero:
+  enabled: false
+  hosts: []                 # e.g. [chart-example.local]
+  excludePathPrefixes: []   # e.g. [/api, /ws]
+  entryPoint: websecure
+  # Without the provider's ingressClass annotation Traefik silently skips the IngressRoute.
+  annotations: {}           # e.g. {kubernetes.io/ingress.class: traefik}
+  interceptor:
+    name: ""                # e.g. keda-add-ons-http-interceptor-proxy
+    namespace: ""
+    port: 8080
+  minReplicas: 0
+  maxReplicas: 1
+  scaledownPeriod: 300
+  targetConcurrency: 10
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## What & Why
Adds an opt-in `scaleToZero` block to the `api-deployment` chart — request-driven scale-to-zero via the KEDA HTTP add-on — mirroring the same feature just added to the `gui` chart in negsoft-negsoft. Lets an api service sleep at zero replicas and cold-start on the first request.

## Key Changes
- New templates: `scaletozero-ingressroute.yaml` (Traefik `IngressRoute` → cross-namespace KEDA interceptor, with `excludePathPrefixes`) and `scaletozero-httpscaledobject.yaml` (KEDA `HTTPScaledObject` → this chart's deployment).
- `scaleToZero` values block, **default `enabled: false`** → existing api releases render nothing new.
- Chart `0.5.1 → 0.6.0`.

## Notes
- Requires Traefik `providers.kubernetesCRD.allowCrossNamespace=true` (set on `gke-mts-prod-euw4-01`).
- `helm template` renders nothing when off; renders both resources when enabled. `helm lint` clean.
- Path-prefix-stripped api routes don't compose with the interceptor (it doesn't rewrite paths) — that's a per-service routing concern, not a chart limitation.
