### PR TITLE
feat: api-deployment scaleToZero include-mode + strip/tag routing

### DIFF
--- a/charts/api-deployment/Chart.yaml
+++ b/charts/api-deployment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api-deployment/templates/_helpers.tpl
+++ b/charts/api-deployment/templates/_helpers.tpl
@@ -62,14 +62,11 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Header the chart injects (Traefik) and matches (HSO) so the shared interceptor can route a
-strip-prefixed service. Single-sourced so the two sides cannot drift; value is the fullname.
+The tag Traefik injects and the HSO matches, so the shared interceptor can still route a
+strip-prefixed service after its path prefix is gone. Single-sourced so the two can't drift.
 */}}
 {{- define "api-deployment.scaleToZero.routingHeaderName" -}}X-Keda-Target{{- end -}}
 
-{{/*
-Fail fast on conflicting or incomplete scaleToZero config.
-*/}}
 {{- define "api-deployment.scaleToZero.validate" -}}
 {{- if .Values.scaleToZero.enabled -}}
 {{- $stz := .Values.scaleToZero -}}

--- a/charts/api-deployment/templates/_helpers.tpl
+++ b/charts/api-deployment/templates/_helpers.tpl
@@ -74,7 +74,9 @@ Fail fast on conflicting or incomplete scaleToZero config.
 {{- if .Values.scaleToZero.enabled -}}
 {{- $stz := .Values.scaleToZero -}}
 {{- if not $stz.hosts }}{{ fail "scaleToZero.enabled requires scaleToZero.hosts" }}{{- end -}}
-{{- if and $stz.pathPrefixes $stz.excludePathPrefixes }}{{ fail "scaleToZero: set pathPrefixes OR excludePathPrefixes, not both" }}{{- end -}}
+{{- if not $stz.interceptor }}{{ fail "scaleToZero.enabled requires scaleToZero.interceptor (name + namespace)" }}{{- end -}}
+{{- if not $stz.interceptor.name }}{{ fail "scaleToZero.interceptor.name is required" }}{{- end -}}
+{{- if not $stz.interceptor.namespace }}{{ fail "scaleToZero.interceptor.namespace is required" }}{{- end -}}
 {{- if and $stz.stripPrefix (not $stz.pathPrefixes) }}{{ fail "scaleToZero.stripPrefix requires pathPrefixes (the prefixes to strip)" }}{{- end -}}
 {{- if .Values.ingress.enabled }}{{ fail "scaleToZero and ingress are mutually exclusive — disable ingress" }}{{- end -}}
 {{- if .Values.autoscaling.enabled }}{{ fail "scaleToZero scales replicas via KEDA — disable autoscaling (HPA)" }}{{- end -}}

--- a/charts/api-deployment/templates/_helpers.tpl
+++ b/charts/api-deployment/templates/_helpers.tpl
@@ -62,11 +62,20 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Header the chart injects (Traefik) and matches (HSO) so the shared interceptor can route a
+strip-prefixed service. Single-sourced so the two sides cannot drift; value is the fullname.
+*/}}
+{{- define "api-deployment.scaleToZero.routingHeaderName" -}}X-Keda-Target{{- end -}}
+
+{{/*
 Fail fast on conflicting or incomplete scaleToZero config.
 */}}
 {{- define "api-deployment.scaleToZero.validate" -}}
 {{- if .Values.scaleToZero.enabled -}}
-{{- if not .Values.scaleToZero.hosts }}{{ fail "scaleToZero.enabled requires scaleToZero.hosts" }}{{- end -}}
+{{- $stz := .Values.scaleToZero -}}
+{{- if not $stz.hosts }}{{ fail "scaleToZero.enabled requires scaleToZero.hosts" }}{{- end -}}
+{{- if and $stz.pathPrefixes $stz.excludePathPrefixes }}{{ fail "scaleToZero: set pathPrefixes OR excludePathPrefixes, not both" }}{{- end -}}
+{{- if and $stz.stripPrefix (not $stz.pathPrefixes) }}{{ fail "scaleToZero.stripPrefix requires pathPrefixes (the prefixes to strip)" }}{{- end -}}
 {{- if .Values.ingress.enabled }}{{ fail "scaleToZero and ingress are mutually exclusive — disable ingress" }}{{- end -}}
 {{- if .Values.autoscaling.enabled }}{{ fail "scaleToZero scales replicas via KEDA — disable autoscaling (HPA)" }}{{- end -}}
 {{- end -}}

--- a/charts/api-deployment/templates/deployment.yaml
+++ b/charts/api-deployment/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "api-deployment.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not (or .Values.autoscaling.enabled .Values.scaleToZero.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:

--- a/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
+++ b/charts/api-deployment/templates/scaletozero-httpscaledobject.yaml
@@ -11,6 +11,17 @@ metadata:
 spec:
   hosts:
     {{- toYaml $stz.hosts | nindent 4 }}
+  pathPrefixes:
+    {{- if and $stz.pathPrefixes (not $stz.stripPrefix) }}
+    {{- toYaml $stz.pathPrefixes | nindent 4 }}
+    {{- else }}
+    - /
+    {{- end }}
+  {{- if $stz.stripPrefix }}
+  headers:
+    - name: {{ include "api-deployment.scaleToZero.routingHeaderName" . }}
+      value: {{ $fullName | quote }}
+  {{- end }}
   scaledownPeriod: {{ $stz.scaledownPeriod | default 300 }}
   scalingMetric:
     concurrency:

--- a/charts/api-deployment/templates/scaletozero-ingressroute.yaml
+++ b/charts/api-deployment/templates/scaletozero-ingressroute.yaml
@@ -19,9 +19,6 @@ spec:
   routes:
     {{- range $host := $stz.hosts }}
     {{- $clauses := list (printf "Host(`%s`)" $host) }}
-    {{- range $p := $stz.excludePathPrefixes }}
-    {{- $clauses = append $clauses (printf "!PathPrefix(`%s`)" $p) }}
-    {{- end }}
     {{- if $stz.pathPrefixes }}
     {{- $incl := list }}
     {{- range $p := $stz.pathPrefixes }}
@@ -37,8 +34,8 @@ spec:
         - name: {{ $fullName }}-scaletozero-tag
       {{- end }}
       services:
-        - name: {{ required "scaleToZero.interceptor.name is required" $stz.interceptor.name }}
-          namespace: {{ required "scaleToZero.interceptor.namespace is required" $stz.interceptor.namespace }}
+        - name: {{ $stz.interceptor.name }}
+          namespace: {{ $stz.interceptor.namespace }}
           port: {{ $stz.interceptor.port | default 8080 }}
     {{- end }}
 {{- end }}

--- a/charts/api-deployment/templates/scaletozero-ingressroute.yaml
+++ b/charts/api-deployment/templates/scaletozero-ingressroute.yaml
@@ -17,9 +17,25 @@ spec:
   entryPoints:
     - {{ $stz.entryPoint | default "websecure" }}
   routes:
-    {{- range $stz.hosts }}
-    - match: Host(`{{ . }}`){{- range $stz.excludePathPrefixes }} && !PathPrefix(`{{ . }}`){{- end }}
+    {{- range $host := $stz.hosts }}
+    {{- $clauses := list (printf "Host(`%s`)" $host) }}
+    {{- range $p := $stz.excludePathPrefixes }}
+    {{- $clauses = append $clauses (printf "!PathPrefix(`%s`)" $p) }}
+    {{- end }}
+    {{- if $stz.pathPrefixes }}
+    {{- $incl := list }}
+    {{- range $p := $stz.pathPrefixes }}
+    {{- $incl = append $incl (printf "PathPrefix(`%s`)" $p) }}
+    {{- end }}
+    {{- $clauses = append $clauses (printf "(%s)" (join " || " $incl)) }}
+    {{- end }}
+    - match: {{ join " && " $clauses }}
       kind: Rule
+      {{- if $stz.stripPrefix }}
+      middlewares:
+        - name: {{ $fullName }}-scaletozero-strip
+        - name: {{ $fullName }}-scaletozero-tag
+      {{- end }}
       services:
         - name: {{ required "scaleToZero.interceptor.name is required" $stz.interceptor.name }}
           namespace: {{ required "scaleToZero.interceptor.namespace is required" $stz.interceptor.namespace }}

--- a/charts/api-deployment/templates/scaletozero-middleware.yaml
+++ b/charts/api-deployment/templates/scaletozero-middleware.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.scaleToZero.enabled .Values.scaleToZero.stripPrefix }}
+{{- $fullName := include "api-deployment.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+# Strips the matched prefix so the app (which serves at root) sees the path unchanged.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullName }}-scaletozero-strip
+  labels:
+    {{- include "api-deployment.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      {{- toYaml $stz.pathPrefixes | nindent 6 }}
+---
+# Tags the request so the shared interceptor can route it after the prefix is gone.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullName }}-scaletozero-tag
+  labels:
+    {{- include "api-deployment.labels" . | nindent 4 }}
+spec:
+  headers:
+    customRequestHeaders:
+      {{ include "api-deployment.scaleToZero.routingHeaderName" . }}: {{ $fullName | quote }}
+{{- end }}

--- a/charts/api-deployment/templates/scaletozero-middleware.yaml
+++ b/charts/api-deployment/templates/scaletozero-middleware.yaml
@@ -1,7 +1,6 @@
 {{- if and .Values.scaleToZero.enabled .Values.scaleToZero.stripPrefix }}
 {{- $fullName := include "api-deployment.fullname" . -}}
 {{- $stz := .Values.scaleToZero -}}
-# Strips the matched prefix so the app (which serves at root) sees the path unchanged.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -13,7 +12,6 @@ spec:
     prefixes:
       {{- toYaml $stz.pathPrefixes | nindent 6 }}
 ---
-# Tags the request so the shared interceptor can route it after the prefix is gone.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -67,10 +67,8 @@ ingress:
 scaleToZero:
   enabled: false
   hosts: []                 # e.g. [chart-example.local]
-  pathPrefixes: []          # the path slice this service owns; empty = whole host; e.g. [/api]
-  # Strip the matched pathPrefixes before the interceptor (apps that serve at root). The chart
-  # then tags the request with a derived header and matches it on the HSO, so the shared
-  # interceptor still routes correctly. Requires pathPrefixes.
+  pathPrefixes: []          # path slice this service owns (empty = whole host); e.g. [/api]
+  # Strip the matched prefix before the interceptor — for apps that serve at root.
   stripPrefix: false
   entryPoint: websecure
   # Without the provider's ingressClass annotation Traefik silently skips the IngressRoute.

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -67,9 +67,7 @@ ingress:
 scaleToZero:
   enabled: false
   hosts: []                 # e.g. [chart-example.local]
-  # Path scope routed to the interceptor — set ONE of these:
-  excludePathPrefixes: []   # catch-all minus these (host's fallback service); e.g. [/api, /ws]
-  pathPrefixes: []          # only these (a slice of the host); e.g. [/api]
+  pathPrefixes: []          # the path slice this service owns; empty = whole host; e.g. [/api]
   # Strip the matched pathPrefixes before the interceptor (apps that serve at root). The chart
   # then tags the request with a derived header and matches it on the HSO, so the shared
   # interceptor still routes correctly. Requires pathPrefixes.

--- a/charts/api-deployment/values.yaml
+++ b/charts/api-deployment/values.yaml
@@ -67,7 +67,13 @@ ingress:
 scaleToZero:
   enabled: false
   hosts: []                 # e.g. [chart-example.local]
-  excludePathPrefixes: []   # e.g. [/api, /ws]
+  # Path scope routed to the interceptor — set ONE of these:
+  excludePathPrefixes: []   # catch-all minus these (host's fallback service); e.g. [/api, /ws]
+  pathPrefixes: []          # only these (a slice of the host); e.g. [/api]
+  # Strip the matched pathPrefixes before the interceptor (apps that serve at root). The chart
+  # then tags the request with a derived header and matches it on the HSO, so the shared
+  # interceptor still routes correctly. Requires pathPrefixes.
+  stripPrefix: false
   entryPoint: websecure
   # Without the provider's ingressClass annotation Traefik silently skips the IngressRoute.
   annotations: {}           # e.g. {kubernetes.io/ingress.class: traefik}


### PR DESCRIPTION
## What & Why
Generalizes the `api-deployment` chart's `scaleToZero` so a service can scale to zero while owning only a path-slice of a shared host (e.g. api-http under `/api`), not just the catch-all form. Unblocks beta `api-http` scale-to-zero with **no app change** — the prefix strip stays in Traefik.

## Key Changes
- `pathPrefixes` (include scope) alongside `excludePathPrefixes` (catch-all-minus); mutually exclusive.
- `stripPrefix`: strips the matched prefix in Traefik **and** tags the request with a derived header (`X-Keda-Target: <fullname>`), matched on the HSO — so the shared KEDA interceptor still routes after the path is gone (it forwards as-is and cannot route on a stripped path).
- New `Middleware` template (stripPrefix + header) gated on `stripPrefix`. Tag is single-sourced so route and HSO matcher cannot drift.
- Deployment `replicas` now gated on `scaleToZero` too (KEDA owns replicas, same as HPA).
- Fail-fast validation: both path modes set, or strip without pathPrefixes.
- `0.6.0 → 0.7.0`.

## Testing
`helm template` across all modes (off → 0 resources, exclude, include+strip) + all 5 validation failures; `helm lint` clean. Header routing + path-forwarded-as-is proven live against the 0.15.0 interceptor (tagged→A, untagged→fallback, wrong-tag→fallback).

## Deployment Notes
Backward-compatible: new templates gated on `scaleToZero.enabled` (off by default), so existing releases render identically. Requires Traefik `providers.kubernetesCRD.allowCrossNamespace=true` (already set on ew4) only when enabled.