### PR TITLE
feat: default chart scaleToZero (KEDA interceptor routing)

### DIFF
--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/default/templates/_helpers.tpl
+++ b/charts/default/templates/_helpers.tpl
@@ -60,3 +60,24 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+The tag Traefik injects and the HSO matches, so the shared interceptor can route this service
+when the path can't (stripped prefix, or an overlapping/complex match). Single-sourced so the
+two sides can't drift.
+*/}}
+{{- define "default.scaleToZero.routingHeaderName" -}}X-Keda-Target{{- end -}}
+
+{{- define "default.scaleToZero.validate" -}}
+{{- if .Values.scaleToZero.enabled -}}
+{{- $stz := .Values.scaleToZero -}}
+{{- if not $stz.hosts }}{{ fail "scaleToZero.enabled requires scaleToZero.hosts" }}{{- end -}}
+{{- if not $stz.interceptor }}{{ fail "scaleToZero.enabled requires scaleToZero.interceptor (name + namespace)" }}{{- end -}}
+{{- if not $stz.interceptor.name }}{{ fail "scaleToZero.interceptor.name is required" }}{{- end -}}
+{{- if not $stz.interceptor.namespace }}{{ fail "scaleToZero.interceptor.namespace is required" }}{{- end -}}
+{{- if and $stz.pathPrefixes $stz.paths }}{{ fail "scaleToZero: set pathPrefixes OR paths, not both" }}{{- end -}}
+{{- if and $stz.stripPrefix (not $stz.pathPrefixes) }}{{ fail "scaleToZero.stripPrefix requires pathPrefixes (the prefixes to strip)" }}{{- end -}}
+{{- if .Values.ingress.enabled }}{{ fail "scaleToZero and ingress are mutually exclusive — disable ingress" }}{{- end -}}
+{{- if .Values.autoscaling.enabled }}{{ fail "scaleToZero scales replicas via KEDA — disable autoscaling (HPA)" }}{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/default/templates/deployment.yaml
+++ b/charts/default/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "default.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not (or .Values.autoscaling.enabled .Values.scaleToZero.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:

--- a/charts/default/templates/scaletozero-httpscaledobject.yaml
+++ b/charts/default/templates/scaletozero-httpscaledobject.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.scaleToZero.enabled }}
+{{- include "default.scaleToZero.validate" . }}
+{{- $fullName := include "default.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "default.labels" . | nindent 4 }}
+spec:
+  hosts:
+    {{- toYaml $stz.hosts | nindent 4 }}
+  pathPrefixes:
+    {{- if and $stz.pathPrefixes (not $stz.stripPrefix) }}
+    {{- toYaml $stz.pathPrefixes | nindent 4 }}
+    {{- else }}
+    - /
+    {{- end }}
+  {{- if $stz.tag }}
+  headers:
+    - name: {{ include "default.scaleToZero.routingHeaderName" . }}
+      value: {{ $fullName | quote }}
+  {{- end }}
+  scaledownPeriod: {{ $stz.scaledownPeriod | default 300 }}
+  scalingMetric:
+    concurrency:
+      targetValue: {{ $stz.targetConcurrency | default 10 }}
+  scaleTargetRef:
+    name: {{ $fullName }}
+    kind: Deployment
+    apiVersion: apps/v1
+    service: {{ $fullName }}
+    port: {{ .Values.service.port }}
+  replicas:
+    min: {{ $stz.minReplicas | default 0 }}
+    max: {{ $stz.maxReplicas | default 1 }}
+{{- end }}

--- a/charts/default/templates/scaletozero-ingressroute.yaml
+++ b/charts/default/templates/scaletozero-ingressroute.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.scaleToZero.enabled }}
+{{- include "default.scaleToZero.validate" . }}
+{{- $fullName := include "default.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+# Cross-namespace service ref → requires Traefik providers.kubernetesCRD.allowCrossNamespace=true.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}-interceptor
+  {{- with $stz.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "default.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $stz.entryPoint | default "websecure" }}
+  routes:
+    {{- range $host := $stz.hosts }}
+    {{- $clauses := list (printf "Host(`%s`)" $host) }}
+    {{- if or $stz.paths $stz.pathPrefixes }}
+    {{- $kw := ternary "Path" "PathPrefix" (not (empty $stz.paths)) }}
+    {{- $items := $stz.paths | default $stz.pathPrefixes }}
+    {{- $incl := list }}
+    {{- range $p := $items }}
+    {{- $incl = append $incl (printf "%s(`%s`)" $kw $p) }}
+    {{- end }}
+    {{- $clauses = append $clauses (printf "(%s)" (join " || " $incl)) }}
+    {{- end }}
+    - match: '{{ join " && " $clauses }}'
+      kind: Rule
+      {{- if or $stz.stripPrefix $stz.tag }}
+      middlewares:
+        {{- if $stz.stripPrefix }}
+        - name: {{ $fullName }}-scaletozero-strip
+        {{- end }}
+        {{- if $stz.tag }}
+        - name: {{ $fullName }}-scaletozero-tag
+        {{- end }}
+      {{- end }}
+      services:
+        - name: {{ $stz.interceptor.name }}
+          namespace: {{ $stz.interceptor.namespace }}
+          port: {{ $stz.interceptor.port | default 8080 }}
+    {{- end }}
+{{- end }}

--- a/charts/default/templates/scaletozero-middleware.yaml
+++ b/charts/default/templates/scaletozero-middleware.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.scaleToZero.enabled }}
+{{- $fullName := include "default.fullname" . -}}
+{{- $stz := .Values.scaleToZero -}}
+{{- if $stz.stripPrefix }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullName }}-scaletozero-strip
+  labels:
+    {{- include "default.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      {{- toYaml $stz.pathPrefixes | nindent 6 }}
+{{- end }}
+{{- if $stz.tag }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullName }}-scaletozero-tag
+  labels:
+    {{- include "default.labels" . | nindent 4 }}
+spec:
+  headers:
+    customRequestHeaders:
+      {{ include "default.scaleToZero.routingHeaderName" . }}: {{ $fullName | quote }}
+{{- end }}
+{{- end }}

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -57,6 +57,28 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Request-driven scale-to-zero via the KEDA HTTP add-on. Needs Traefik
+# providers.kubernetesCRD.allowCrossNamespace=true; disable `ingress` when enabling.
+scaleToZero:
+  enabled: false
+  hosts: []                 # e.g. [chart-example.local]
+  # Traffic this service claims on the host — set ONE (or neither = whole-host catch-all):
+  pathPrefixes: []          # PathPrefix matchers (prefix), e.g. [/api]
+  paths: []                 # Path matchers (exact; Traefik v2 {name:regex} groups allowed), e.g. [/assets/{rest:.*}, /dynamic/erp/items]
+  stripPrefix: false        # strip the matched pathPrefixes before the interceptor (apps serving at root); needs pathPrefixes
+  tag: false                # tag the request so the shared interceptor can route it when the path can't (strip, or overlapping/complex match)
+  entryPoint: websecure
+  # Without the provider's ingressClass annotation Traefik silently skips the IngressRoute.
+  annotations: {}           # e.g. {kubernetes.io/ingress.class: traefik}
+  interceptor:
+    name: ""                # e.g. keda-add-ons-http-interceptor-proxy
+    namespace: ""
+    port: 8080
+  minReplicas: 0
+  maxReplicas: 1
+  scaledownPeriod: 300
+  targetConcurrency: 10
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## What & Why
Adds reusable request-driven scale-to-zero to the generic `default` chart, so **any** `default`-chart deployment can opt in (third scale-to-zero shape after `api-deployment` and the `gui` chart). First consumer: the modern Angular GUI (`negsoft-gui`).

## Key Changes
- `scaleToZero`: `hosts` + (`pathPrefixes` | `paths` | neither = whole-host catch-all) + optional `stripPrefix` + optional `tag` (**decoupled** — the modern GUI needs a tag with no strip).
- `paths` is a clean YAML **list of exact `Path()` matchers** — the same path list other envs already keep under `ingress` — so the values stay readable (no giant rule string).
- Generates the `IngressRoute` (→ interceptor), strip/tag `Middleware`s, and `HTTPScaledObject` together; the tag value is single-sourced via a helper so route, middleware and HSO can't drift.
- Deployment `replicas` gated on `scaleToZero` too (KEDA owns them).
- `0.3.0 → 0.4.0`.

## Why an IngressRoute and not a classic Ingress
Scale-to-zero routes traffic to the KEDA interceptor in another namespace (`platform-autoscaling`); a k8s Ingress can only target same-namespace services, so the cross-namespace hop needs a Traefik `IngressRoute`. The `paths` list keeps the values as clean as the Ingress form.

## Testing
`helm template` across all shapes (off → 0; pathPrefixes+strip+tag; paths+tag; catch-all) + fail-fast validation; `helm lint` clean. Verified regex paths render intact and the HSO targets the right deployment.

## Deployment Notes
Backward-compatible: gated on `scaleToZero.enabled` (off by default). Needs Traefik `providers.kubernetesCRD.allowCrossNamespace=true` (already set on ew4) only when enabled.