### PR TITLE
docs: trim default chart scaleToZero values comments

### DIFF
--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -62,11 +62,10 @@ ingress:
 scaleToZero:
   enabled: false
   hosts: []                 # e.g. [chart-example.local]
-  # Traffic this service claims on the host — set ONE (or neither = whole-host catch-all):
-  pathPrefixes: []          # PathPrefix matchers (prefix), e.g. [/api]
-  paths: []                 # Path matchers (exact; Traefik v2 {name:regex} groups allowed), e.g. [/assets/{rest:.*}, /dynamic/erp/items]
-  stripPrefix: false        # strip the matched pathPrefixes before the interceptor (apps serving at root); needs pathPrefixes
-  tag: false                # tag the request so the shared interceptor can route it when the path can't (strip, or overlapping/complex match)
+  pathPrefixes: []          # e.g. [/api]
+  paths: []                 # exact paths, e.g. [/assets/{rest:.*}]
+  stripPrefix: false        # for apps that serve at root
+  tag: false                # when the path can't disambiguate at the interceptor
   entryPoint: websecure
   # Without the provider's ingressClass annotation Traefik silently skips the IngressRoute.
   annotations: {}           # e.g. {kubernetes.io/ingress.class: traefik}


### PR DESCRIPTION
Follow-up to #33: trims the `scaleToZero` values comments to load-bearing hints only (drops the section header, the validation-redundant `needs pathPrefixes`, and the over-long strip/tag sentences). Values-only, no template change. `0.4.0 → 0.4.1`.